### PR TITLE
PSR2: Fixes indentation of comments in beginning of lines and continued statements, also whitespaces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,9 @@ By default PHP Mode tries to provide a reasonable style for indentation and form
 2. `php-enable-drupal-coding-style`
 3. `php-enable-wordpress-coding-style`
 4. `php-enable-symfony2-coding-style`
+5. `php-enable-psr2-coding-style`
 
-They will help format your code for PEAR projects, or work on Drupal, WordPress, and Symfony2 software, respectively.  You may enable any of them by default by running `M-x customize-group <RET> php` and looking for the ‘PHP Mode Coding Style’ option.
+They will help format your code for PEAR/PSR-2 projects, or work on Drupal, WordPress, and Symfony2 software, respectively.  You may enable any of them by default by running `M-x customize-group <RET> php` and looking for the ‘PHP Mode Coding Style’ option.
 
 #### Symfony2 Style ####
 

--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -202,8 +202,10 @@ style from Drupal."
    (search-forward "return $this->bar;")
    ;; the file written to has no significance, only the buffer
    (let ((tmp-filename (make-temp-name temporary-file-directory)))
-     (dolist (mode '(pear wordpress symfony2 psr2))
+     (dolist (mode '(pear wordpress symfony2))
        (php-mode-custom-coding-style-set 'php-mode-coding-style 'drupal)
+       (php-mode-custom-coding-style-set 'php-mode-coding-style mode)
+       (php-mode-custom-coding-style-set 'php-mode-coding-style 'psr2)
        (php-mode-custom-coding-style-set 'php-mode-coding-style mode)
        (should-not show-trailing-whitespace)
        (write-file tmp-filename)

--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -205,6 +205,7 @@ style from Drupal."
      (dolist (mode '(pear wordpress symfony2))
        (php-mode-custom-coding-style-set 'php-mode-coding-style 'drupal)
        (php-mode-custom-coding-style-set 'php-mode-coding-style mode)
+       (should-not show-trailing-whitespace)
        (php-mode-custom-coding-style-set 'php-mode-coding-style 'psr2)
        (php-mode-custom-coding-style-set 'php-mode-coding-style mode)
        (should-not show-trailing-whitespace)

--- a/php-mode.el
+++ b/php-mode.el
@@ -669,7 +669,8 @@ working with Symfony2."
 
 (c-add-style
   "psr2"
-  '("php"))
+  '("php"
+     (c-offsets-alist . ((statement-cont . +)))))
 
 (defun php-enable-psr2-coding-style ()
   "Makes php-mode comply to the PSR-2 coding style"

--- a/php-mode.el
+++ b/php-mode.el
@@ -597,8 +597,8 @@ code and modules."
         indent-tabs-mode nil)
   (c-set-style "pear")
 
-  ;; Undo drupal coding style whitespace effects
-  (setq show-trailing-whitespace nil)
+  ;; Undo drupal/PSR-2 coding style whitespace effects
+  (set (make-local-variable 'show-trailing-whitespace) nil)
   (remove-hook 'before-save-hook 'delete-trailing-whitespace))
 
 (c-add-style

--- a/php-mode.el
+++ b/php-mode.el
@@ -11,7 +11,7 @@
 (defconst php-mode-version-number "1.13.5"
   "PHP Mode version number.")
 
-(defconst php-mode-modified "2014-09-27"
+(defconst php-mode-modified "2014-10-05"
   "PHP Mode build date.")
 
 ;;; License
@@ -442,7 +442,7 @@ This variable can take one of the following symbol values:
   ;; falls back to java, so no need to specify the language
   php (append (remove ">>>=" (c-lang-const c-assignment-operators))
               '(".=")))
- 
+
 (c-lang-defconst beginning-of-defun-function
   php 'php-beginning-of-defun)
 
@@ -578,7 +578,8 @@ PHP does not have an \"enum\"-like keyword."
                        (label . +)
                        (arglist-cont-nonempty . (first c-lineup-cascaded-calls c-lineup-arglist))
                        (arglist-intro . php-lineup-arglist-intro)
-                       (arglist-close . php-lineup-arglist-close)))))
+                       (arglist-close . php-lineup-arglist-close)
+                       (comment-intro . 0)))))
 
 (add-to-list 'c-default-style '(php-mode . "php"))
 

--- a/php-mode.el
+++ b/php-mode.el
@@ -617,8 +617,8 @@ working with Drupal."
   (interactive)
   (setq tab-width 2
         indent-tabs-mode nil
-        fill-column 78
-        show-trailing-whitespace t)
+        fill-column 78)
+  (set (make-local-variable 'show-trailing-whitespace) t)
   (add-hook 'before-save-hook 'delete-trailing-whitespace)
   (c-set-style "drupal"))
 
@@ -644,8 +644,8 @@ working with Wordpress."
         c-indent-comments-syntactically-p t)
   (c-set-style "wordpress")
 
-  ;; Undo drupal coding style whitespace effects
-  (setq show-trailing-whitespace nil)
+  ;; Undo drupal/PSR-2 coding style whitespace effects
+  (set (make-local-variable 'show-trailing-whitespace) nil)
   (remove-hook 'before-save-hook 'delete-trailing-whitespace))
 
 (c-add-style
@@ -663,8 +663,8 @@ working with Symfony2."
         require-final-newline t)
   (c-set-style "symfony2")
 
-  ;; Undo drupal coding style whitespace effects
-  (setq show-trailing-whitespace nil)
+  ;; Undo drupal/PSR-2 coding style whitespace effects
+  (set (make-local-variable 'show-trailing-whitespace) nil)
   (remove-hook 'before-save-hook 'delete-trailing-whitespace))
 
 (c-add-style
@@ -681,9 +681,10 @@ working with Symfony2."
         require-final-newline t)
   (c-set-style "psr2")
 
-  ;; Undo drupal coding style whitespace effects
-  (setq show-trailing-whitespace nil)
-  (remove-hook 'before-save-hook 'delete-trailing-whitespace))
+  ;; Apply drupal-like coding style whitespace effects
+  (set (make-local-variable 'require-final-newline) t)
+  (set (make-local-variable 'show-trailing-whitespace) t)
+  (add-hook 'before-save-hook 'delete-trailing-whitespace))
 
 (defconst php-beginning-of-defun-regexp
   "^\\s-*\\(?:\\(?:abstract\\|final\\|private\\|protected\\|public\\|static\\)\\s-+\\)*function\\s-+&?\\(\\(?:\\sw\\|\\s_\\)+\\)\\s-*("


### PR DESCRIPTION
What has been going on the last few months when I haven't looked here? Alot of structural changes I see.

Anyways, some stuff was lost since I upgraded:
- Indention of comments starting at beginning of line: 4ce90c3
- And continued statements: 8a81ed8