### PR TITLE
No default method lineup and allow customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ PHP Mode treats underscores as ‘symbol constituents’ (in Emacs terminology) 
 
 ### Chained Method Calls ###
 
-PHP Mode will align method calls over multiple lines anchored around the `->` operator, e.g.:
+PHP Mode can align method calls over multiple lines anchored around the `->` operator, e.g.:
 
 ```php
 $object->foo()
@@ -67,7 +67,9 @@ $object->foo()
        ->baz();
 ```
 
-**Note:** Alignment will only work if you use one of the coding styles described below.  PHP Mode uses [CC mode][] for indentation.  If you use any indentation style other than those described under the *Coding Styles* section then the method alignment above is not guaranteed to work.
+This behaviour is off by default, but you can customize the variable `php-lineup-cascaded-calls` to enable this.
+
+**Note:** Alignment will only work if you use one of the php-mode coding styles or inherit one of the styles.
 
 ### Nested Array Formatting ###
 

--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -70,7 +70,7 @@ be processed."
                        answers))))
      answers)))
 
-(defmacro* with-php-mode-test ((file &key style indent magic) &rest body)
+(defmacro* with-php-mode-test ((file &key style indent magic custom) &rest body)
   "Set up environment for testing `php-mode'.
 Execute BODY in a temporary buffer containing the contents of
 FILE, in `php-mode'. Optional keyword `:style' can be used to set
@@ -82,7 +82,11 @@ the coding style to one of the following:
 4. `symfony2'
 
 Using any other symbol for STYLE results in undefined behavior.
-The test will use the PEAR style by default."
+The test will use the PEAR style by default.
+
+If the `:custom' keyword is set, customized variables are not reset to
+their default state prior to starting the test. Use this if the test should
+run with specific customizations set."
   (declare (indent 1))
   `(with-temp-buffer
      (insert-file-contents (expand-file-name ,file php-mode-test-dir))
@@ -94,6 +98,9 @@ The test will use the PEAR style by default."
         (wordpress '(php-enable-wordpress-coding-style))
         (symfony2 '(php-enable-symfony2-coding-style))
         (t '(php-enable-pear-coding-style)))
+
+     ,(unless custom '(custom-set-variables '(php-lineup-cascaded-calls nil)))
+
      ,(if indent
           '(indent-region (point-min) (point-max)))
      ,(if magic
@@ -142,12 +149,22 @@ Gets the face of the text after the comma."
 
 (ert-deftest php-mode-test-issue-19 ()
   "Alignment of arrow operators."
-  (with-php-mode-test ("issue-19.php" :indent t)
+  (custom-set-variables '(php-lineup-cascaded-calls t))
+  (with-php-mode-test ("issue-19.php" :indent t :custom t)
     (while (search-forward "$object->" (point-max) t)
       ;; Point is just after `->'
       (let ((col (current-column)))
         (search-forward "->")
-        (should (= (current-column) col))))))
+        (should (= (current-column) col)))))
+
+  ;; Test indentation again, but without php-lineup-cascaded-calls enabled
+  (with-php-mode-test ("issue-19.php" :indent t)
+    (while (search-forward "\\($object->\\)" (point-max) t)
+      (match-beginning 0)
+      ;; Point is just on `$'
+      (let ((col (current-column)))
+        (search-forward "->")
+        (should (= (current-column) (+ col c-basic-offset)))))))
 
 (ert-deftest php-mode-test-issue-21 ()
   "Font locking multi-line string."
@@ -237,11 +254,13 @@ style from Drupal."
 
 (ert-deftest php-mode-test-issue-115 ()
   "Proper alignment for chained method calls inside arrays."
-  (with-php-mode-test ("issue-115.php" :indent t :magic t)))
+  (custom-set-variables '(php-lineup-cascaded-calls t))
+  (with-php-mode-test ("issue-115.php" :indent t :magic t :custom t)))
 
 (ert-deftest php-mode-test-issue-135 ()
   "Proper alignment multiline statements."
-  (with-php-mode-test ("issue-135.php" :indent t :magic t)))
+  (custom-set-variables '(php-lineup-cascaded-calls t))
+  (with-php-mode-test ("issue-135.php" :indent t :magic t :custom t)))
 
 (ert-deftest php-mode-test-issue-130 ()
   "Proper alignment array elements."

--- a/php-mode.el
+++ b/php-mode.el
@@ -159,6 +159,11 @@ of constants when set."
      'php-mode `((,(php-mode-extra-constants-create-regexp value) 1 font-lock-constant-face))))
   (set sym value))
 
+(defcustom php-lineup-cascaded-calls nil
+  "Indent chained method calls to the previous line"
+  :type 'boolean
+  :group 'php)
+
 ;;;###autoload
 (defcustom php-extra-constants '()
   "A list of additional strings to treat as PHP constants."
@@ -560,22 +565,28 @@ might be to handle switch and goto labels differently."
                                (c-lang-const c-constant-kwds))
                        :test 'string-equal))))
 
+(defun php-lineup-cascaded-calls (langelem)
+  "Line up chained methods using `c-lineup-cascaded-calls',
+but only if the setting is enabled"
+  (if php-lineup-cascaded-calls
+    (c-lineup-cascaded-calls langelem)))
+
 (c-add-style
  "php"
  '((c-basic-offset . 4)
    (c-doc-comment-style . javadoc)
    (c-offsets-alist . ((arglist-close . php-lineup-arglist-close)
-                       (arglist-cont . (first c-lineup-cascaded-calls 0))
-                       (arglist-cont-nonempty . (first c-lineup-cascaded-calls c-lineup-arglist))
+                       (arglist-cont . (first php-lineup-cascaded-calls 0))
+                       (arglist-cont-nonempty . (first php-lineup-cascaded-calls c-lineup-arglist))
                        (arglist-intro . php-lineup-arglist-intro)
                        (case-label . +)
                        (class-open . -)
                        (inlambda . 0)
                        (inline-open . 0)
                        (label . +)
-                       (statement-cont . (first c-lineup-cascaded-calls +))
+                       (statement-cont . (first php-lineup-cascaded-calls +))
                        (substatement-open . 0)
-                       (topmost-intro-cont . (first c-lineup-cascaded-calls +))))))
+                       (topmost-intro-cont . (first php-lineup-cascaded-calls +))))))
 
 (add-to-list 'c-default-style '(php-mode . "php"))
 


### PR DESCRIPTION
Prior to this commit, php-mode lined up cascaded calls by default,
except maybe for a few exceptions in the psr2 style. As discussed
in PR #183 having regular indentation for method calls seems a better
fit.

Users can enable the old behaviour using Emacs' customize interface, or
enable it as part of a mode/style hook.