### PR TITLE
Special highlighting of $this and self/static

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -437,4 +437,17 @@ style from Drupal."
   "Indentation of switch case body preceeded by multiple case statements"
   (with-php-mode-test ("issue-186.php" :indent t :magic t)))
 
+(ert-deftest php-mode-test-issue-201 ()
+  "Test highlighting of special variables"
+  (with-php-mode-test ("issue-201.php")
+    (search-forward "Start:")
+    (search-forward "$this")
+    (should (eq 'font-lock-constant-face (get-text-property (- (point) 1) 'face)))
+    (search-forward "$that")
+    (should (eq 'font-lock-constant-face (get-text-property (- (point) 1) 'face)))
+    (search-forward "self")
+    (should (eq 'font-lock-keyword-face (get-text-property (- (point) 1) 'face)))
+    (search-forward "static")
+    (should (eq 'font-lock-keyword-face (get-text-property (- (point) 1) 'face)))))
+
 ;;; php-mode-test.el ends here

--- a/php-mode.el
+++ b/php-mode.el
@@ -533,9 +533,17 @@ PHP does not have an \"enum\"-like keyword."
     "xor"
     "yield"
 
-    ;; technically not reserved keywords, but "declare directives"
+    ;; Below keywords are technically not reserved keywords, but
+    ;; threated no differently by php-mode from actual reserved
+    ;; keywords
+    ;;
+    ;;; declare directives:
     "encoding"
-    "ticks"))
+    "ticks"
+
+    ;;; self for static references:
+    "self"
+    ))
 
 ;; PHP does not have <> templates/generics
 (c-lang-defconst c-recognize-<>-arglists
@@ -1314,6 +1322,10 @@ a completion list."
      ;; Highlight variables, e.g. 'var' in '$var' and '$obj->var', but
      ;; not in $obj->var()
      ("->\\(\\sw+\\)\\s-*(" 1 'default)
+
+     ;; Highlight special variables
+     ("\\$\\(this\\|that\\)" 1 font-lock-constant-face)
+
      ("\\(\\$\\|->\\)\\([a-zA-Z0-9_]+\\)" 2 font-lock-variable-name-face)
 
      ;; Highlight all upper-cased symbols as constant

--- a/tests/issue-201.php
+++ b/tests/issue-201.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * GitHub Issue:    https://github.com/ejmr/php-mode/issues/201
+ *
+ * Test highighting of $this
+ */
+
+// Start:
+$this;
+$that;
+self::test();
+static::test();


### PR DESCRIPTION
$this (and copied from older php-mode $that) are highlighted with the
constant face instead of plain variable face.

Also, self and static no longer look differently (all keyword face so
those too are now different from other statically called methods).

Fixes issue #201.