### PR TITLE
Fix regexp for imenu to show static method properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ In chronological order:
 61. [Alan Pearce](https://github.com/alanpearce)
 62. Syohei Yoshida
 63. Joris Steyn
+64. l3msh0
 
 
 

--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -234,6 +234,19 @@ style from Drupal."
             (beginning-of-line)
             (should (string= (thing-at-point 'line) correct-line))))))))
 
+(ert-deftest php-mode-test-issue-83 ()
+  "All static method should appear on imenu whether 'static' keyword is placed before or after visibility"
+  (with-php-mode-test
+   ("issue-83.php")
+   (require 'imenu)
+   (let* ((index-alist (imenu--make-index-alist))
+          (public-methods (mapcar 'car (cdr (assoc "Public Methods" index-alist))))
+          (all-methods (mapcar 'car (cdr (assoc "All Methods" index-alist)))))
+     (should (member "staticBeforeVisibility" public-methods))
+     (should (member "staticBeforeVisibility" all-methods))
+     (should (member "staticAfterVisibility" public-methods))
+     (should (member "staticAfterVisibility" all-methods)))))
+
 (ert-deftest php-mode-test-issue-99 ()
   "Proper indentation for 'foreach' statements without braces."
   (with-php-mode-test ("issue-99.php" :indent t :magic t)))

--- a/php-mode.el
+++ b/php-mode.el
@@ -11,7 +11,7 @@
 (defconst php-mode-version-number "1.15.1"
   "PHP Mode version number.")
 
-(defconst php-mode-modified "2014-12-29"
+(defconst php-mode-modified "2015-01-06"
   "PHP Mode build date.")
 
 ;;; License
@@ -191,10 +191,8 @@ which will be the name of the method."
   (concat
    ;; Initial space with possible 'abstract' or 'final' keywords
    "^\\s-*\\(?:\\(?:abstract\\|final\\)\\s-+\\)?"
-   ;; The function visilibity
-   visibility
-   ;; Is it static?
-   "\\s-+\\(?:static\\s-+\\)?"
+   ;; 'static' keyword may come either before or after visibility
+   "\\(?:" visibility "\\(?:\\s-+static\\)?\\|\\(?:static\\s-+\\)?" visibility "\\)\\s-+"
    ;; Make sure 'function' comes next with some space after
    "function\\s-+"
    ;; Capture the name as the first group and the regexp and make sure

--- a/tests/issue-83.php
+++ b/tests/issue-83.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Github Issue:    https://github.com/ejmr/php-mode/issues/83
+ *
+ * All static methods should appear on imenu whether 'static' keyword
+ * is placed before or after visibility.
+ *
+ */
+
+class Test
+{
+	static public function staticBeforeVisibility()
+	{
+		// Do nothing
+	}
+
+	public static function staticAfterVisibility()
+	{
+		// Do nothing
+	}
+}


### PR DESCRIPTION
Add test case for issue #83.

Though we can place 'static' keyword either before or after a visibility
keyword at method definition, imenu has only shown the latter case. This
commit fixes 'php-imenu-generic-expression' for the methods of both case
to appear on imenu.

GitHub-Issue: 83