### PR TITLE
Improve #211

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -494,4 +494,25 @@ style from Drupal."
     (search-forward "static")
     (should (eq 'font-lock-keyword-face (get-text-property (- (point) 1) 'face)))))
 
+(ert-deftest php-mode-test-issue-211 ()
+  "Test indentation of string concatination"
+  (with-php-mode-test ("issue-211.php")
+    (search-forward "\$str =")
+    (let ((equal-indentation (1- (current-column)))) ;; because cursor is after '='
+      (forward-line 1)
+      (call-interactively 'indent-for-tab-command)
+      (should (= (current-column) equal-indentation)))
+
+    (search-forward "\$str_long_name =")
+    (let ((equal-indentation (1- (current-column))))
+      (forward-line 1)
+      (call-interactively 'indent-for-tab-command)
+      (should (= (current-column) equal-indentation)))
+
+    (search-forward "\$sql =")
+    (let ((equal-indentation (1- (current-column))))
+      (forward-line 2)
+      (call-interactively 'indent-for-tab-command)
+      (should (= (current-column) equal-indentation)))))
+
 ;;; php-mode-test.el ends here

--- a/php-mode.el
+++ b/php-mode.el
@@ -877,14 +877,9 @@ $str = 'some'
 this ^ lineup"
   (save-excursion
     (goto-char (cdr langelem))
-    (setq anchor 0)
-    ;; Find equal sign
-    (if (not (<= (setq anchor (re-search-forward "=")) (line-end-position)))
-        ;; Or find dot sign
-        (if (<= (setq anchor (re-search-forward ".")) (line-end-position))))
-    (setq anchor (- anchor (line-beginning-position)))
-    (setq anchor (1- anchor))
-    (vector anchor)))
+    (when (or (search-forward "=" (line-end-position) t)
+              (search-forward "." (line-end-position) t))
+      (vector (1- (current-column))))))
 
 (defun php-lineup-arglist-intro (langelem)
   (save-excursion

--- a/tests/issue-211.php
+++ b/tests/issue-211.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * GitHub Issue:    https://github.com/ejmr/php-mode/issues/211
+ *
+ * Indentation of string concatination
+ */
+
+// Start:
+$str = 'some'
+. 'string1';
+
+$str_long_name = 'some'
+                             . 'string2';
+
+// Multiple lines
+$sql = "SELECT `id`, `name` FROM `people` "
+     . "WHERE `name` = 'Susan' "
+. "ORDER BY `name` ASC ";


### PR DESCRIPTION
- Fix byte compile warnings
- Add unit test
- Correct dot case
  '(re-search-forward ".")' makes no sense. Because '.' matches any
  single character.
- Simplify the code

I got following byte compile warnings with original code.

```
In php-lineup-string-cont:
php-mode.el:872:32:Warning: too few arguments for `if'
php-mode.el:880:11:Warning: assignment to free variable `anchor'
php-mode.el:885:21:Warning: reference to free variable `anchor'
```
