### PR TITLE
Fix expected indentation size

### DIFF
--- a/tests/issue-186.php
+++ b/tests/issue-186.php
@@ -13,27 +13,27 @@
 
 switch (true) {
 case true:
-    echo 'test'; // ###php-mode-test### ((indent c-basic-offset))
-    echo 'test'; // ###php-mode-test### ((indent c-basic-offset))
+    echo 'test'; // ###php-mode-test### ((indent (* c-basic-offset 2)))
+    echo 'test'; // ###php-mode-test### ((indent (* c-basic-offset 2)))
 }
 
 switch (true) {
 case null:
 case false:
-    echo 'test'; // ###php-mode-test### ((indent c-basic-offset))
-    echo 'test'; // ###php-mode-test### ((indent c-basic-offset))
+    echo 'test'; // ###php-mode-test### ((indent (* c-basic-offset 2)))
+    echo 'test'; // ###php-mode-test### ((indent (* c-basic-offset 2)))
 }
 
 switch (true) {
 case "test":
 case "test":
-    echo 'test'; // ###php-mode-test### ((indent c-basic-offset))
-    echo 'test'; // ###php-mode-test### ((indent c-basic-offset))
+    echo 'test'; // ###php-mode-test### ((indent (* c-basic-offset 2)))
+    echo 'test'; // ###php-mode-test### ((indent (* c-basic-offset 2)))
 }
 
 switch (true) {
 case $test:
 case $test:
-    echo 'test'; // ###php-mode-test### ((indent c-basic-offset))
-    echo 'test'; // ###php-mode-test### ((indent c-basic-offset))
+    echo 'test'; // ###php-mode-test### ((indent (* c-basic-offset 2)))
+    echo 'test'; // ###php-mode-test### ((indent (* c-basic-offset 2)))
 }


### PR DESCRIPTION
Default test style 'php' indents 'case'. So 'case' body
is two times more than 'switch'.