### PR TITLE
Improve #201 fix

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -494,6 +494,8 @@ style from Drupal."
     (search-forward "self")
     (should (eq 'font-lock-keyword-face (get-text-property (- (point) 1) 'face)))
     (search-forward "static")
+    (should (eq 'font-lock-keyword-face (get-text-property (- (point) 1) 'face)))
+    (search-forward "parent")
     (should (eq 'font-lock-keyword-face (get-text-property (- (point) 1) 'face)))))
 
 (ert-deftest php-mode-test-issue-211 ()

--- a/php-mode.el
+++ b/php-mode.el
@@ -546,6 +546,7 @@ PHP does not have an \"enum\"-like keyword."
     "isset"
     "list"
     "or"
+    "parent"
     "static"
     "unset"
     "var"
@@ -1340,6 +1341,9 @@ a completion list."
      ;; Highlight variables, e.g. 'var' in '$var' and '$obj->var', but
      ;; not in $obj->var()
      ("->\\(\\sw+\\)\\s-*(" 1 'default)
+
+     ;; Highlight special variables
+     ("\\$\\(this\\|that\\)" 1 font-lock-constant-face)
      ("\\(\\$\\|->\\)\\([a-zA-Z0-9_]+\\)" 2 font-lock-variable-name-face)
 
      ;; Highlight function/method names
@@ -1366,13 +1370,9 @@ a completion list."
    ;;   already fontified by another pattern. Note that using OVERRIDE
    ;;   is usually overkill.
    `(
-     
      ;; Highlight variables, e.g. 'var' in '$var' and '$obj->var', but
      ;; not in $obj->var()
      ("->\\(\\sw+\\)\\s-*(" 1 'default)
-
-     ;; Highlight special variables
-     ("\\$\\(this\\|that\\)" 1 font-lock-constant-face)
 
      ("\\(\\$\\|->\\)\\([a-zA-Z0-9_]+\\)" 2 font-lock-variable-name-face)
 

--- a/tests/issue-201.php
+++ b/tests/issue-201.php
@@ -11,3 +11,4 @@ $this;
 $that;
 self::test();
 static::test();
+parent::test();


### PR DESCRIPTION
- highlight 'parent' as keyword
- fix syntax highlight order

#### Current version
![older](https://cloud.githubusercontent.com/assets/554281/5986345/efee2170-a937-11e4-9a17-def0d4899dee.png)


#### Applied this change
![php-mode](https://cloud.githubusercontent.com/assets/554281/5986335/af49ff4a-a937-11e4-9c05-ba9017f8f253.png)


