### PR TITLE
Fix test

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -447,7 +447,7 @@ style from Drupal."
   (with-php-mode-test ("language-constructs.php")
                       (search-forward "Start:")
                       (while (not (= (line-number-at-pos) (count-lines (point-min) (point-max))))
-                        (next-line)
+                        (forward-line 1)
                         (should (eq 'font-lock-keyword-face
                                     (get-text-property (point) 'face))))))
 


### PR DESCRIPTION
next-line moves to next-line and same column. But it should move
beginning of next line. So we should use forward-line instead of
next-line.