### PR TITLE
Fix chained method indentation for PSR2 style

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -555,5 +555,8 @@ style from Drupal."
   "multi-line strings indents "
   (custom-set-variables '(php-lineup-cascaded-calls t))
   (with-php-mode-test ("issue-227.php" :indent t :style pear)))
+(ert-deftest php-mode-test-issue-237 ()
+  "Indent chaining method for PSR2."
+  (with-php-mode-test ("issue-237.php" :indent t :style psr2 :magic t)))
 
 ;;; php-mode-test.el ends here

--- a/php-mode.el
+++ b/php-mode.el
@@ -689,7 +689,8 @@ working with Symfony2."
 
 (c-add-style
   "psr2"
-  '("php"))
+  '("php"
+    (c-offsets-alist . ((statement-cont . +)))))
 
 (defun php-enable-psr2-coding-style ()
   "Makes php-mode comply to the PSR-2 coding style"

--- a/tests/issue-237.php
+++ b/tests/issue-237.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * GitHub Issue:    https://github.com/ejmr/php-mode/issues/237
+ *
+ * Indentation of chaining method for PSR2
+ */
+
+$provider = $this->di->get('provider')
+->filterByLanguage('en'); // ###php-mode-test### ((indent c-basic-offset))
+
+function foo() {
+    if (true) {
+        $provider = $this->di->get('provier')
+->filterByLanguage('en'); // ###php-mode-test### ((indent (+ c-basic-offset 8)))
+    }
+}


### PR DESCRIPTION
This is related to #237.
@krzysztof-magosa Could you check [this version](https://raw.githubusercontent.com/ejmr/php-mode/a551255444b48cebb96b96e5273cde4ee86ee803/php-mode.el) ?

#### Original

![before](https://cloud.githubusercontent.com/assets/554281/7100767/3110a268-e06f-11e4-90d3-eb3839da4d09.gif)


#### With this patch

![after](https://cloud.githubusercontent.com/assets/554281/7100768/4fba5d1c-e06f-11e4-93ff-d4e7e9d74bd2.gif)
