### PR TITLE
Run tests on emacs 24.4 and 24.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,29 @@
 language: emacs-lisp
+sudo: required
 env:
   matrix:
-    - EMACS=emacs24
-    - EMACS=emacs-snapshot
+    - EMACS_VERSION=emacs-24.3-bin
+    - EMACS_VERSION=emacs-24.4-bin
+    - EMACS_VERSION=emacs-24.5-bin
+    - EMACS_VERSION=emacs-snapshot
+
 before_install:
-  - sudo add-apt-repository -y ppa:cassou/emacs
-  - sudo add-apt-repository -y ppa:ubuntu-elisp/ppa
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq $EMACS
-  - if [ "$EMACS" = 'emacs-snapshot' ]; then
+  # Use the ubuntu emacs teams regularly updated snapshot packages.
+  - if [ "$EMACS_VERSION" = 'emacs-snapshot' ]; then
+      sudo add-apt-repository -y ppa:ubuntu-elisp/ppa &&
+      sudo apt-get update -qq &&
+      sudo apt-get install -qq $EMACS_VERSION &&
       sudo apt-get install -qq emacs-snapshot-el emacs-snapshot-nox;
     fi
+
+  # Use emacs version manager for all other versions.
+  - sudo mkdir /usr/local/evm
+  - sudo chown travis:travis /usr/local/evm
+  - export PATH="/home/travis/.evm/bin:$PATH"
+  - curl -fsSkL https://raw.github.com/rejeep/evm/master/go | bash
+  - evm install $EMACS_VERSION --use || true
+
 script:
-  make test
+  # Make sure the exact emacs version can be found in the build output.
+  - emacs -Q --batch --eval '(message (emacs-version))'
+  - make test


### PR DESCRIPTION
The tests used to run only on 24.3 and snapshot.

I could not find PPAs for the newer versions. They package usually just major versions, and since past few minor versions of emacs where more like major versions [1], it makes sense to test multiple minor versions per major version number.

All versions are installed from EVM (emacs version manager) except snapshot.

[1] http://lists.gnu.org/archive/html/emacs-devel/2014-09/msg00872.html