### PR TITLE
Workaround 253

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -559,4 +559,16 @@ style from Drupal."
   "Indent chaining method for PSR2."
   (with-php-mode-test ("issue-237.php" :indent t :style psr2 :magic t)))
 
+(ert-deftest php-mode-test-issue-253 ()
+  "Test highlight after string literal which contains many escaped quotes."
+  (with-php-mode-test ("issue-253.php")
+    (search-forward "$x" nil nil 3)
+    (should (eq 'font-lock-variable-name-face (get-text-property (1- (point)) 'face)))
+
+    (search-forward "$this")
+    (should (eq 'font-lock-constant-face (get-text-property (1- (point)) 'face)))
+
+    (search-forward "$x")
+    (should (eq 'font-lock-variable-name-face (get-text-property (1- (point)) 'face)))))
+
 ;;; php-mode-test.el ends here

--- a/php-mode.el
+++ b/php-mode.el
@@ -1479,9 +1479,10 @@ The output will appear in the buffer *PHP*."
 
 (defun php-string-intepolated-variable-font-lock-find (limit)
   (while (re-search-forward php-string-interpolated-variable-regexp limit t)
-    (when (php-in-string-p)
-      (put-text-property (match-beginning 0) (match-end 0)
-                         'face 'font-lock-variable-name-face)))
+    (let ((quoted-stuff (nth 3 (syntax-ppss))))
+      (when (and quoted-stuff (member quoted-stuff '(?\" ?`)))
+        (put-text-property (match-beginning 0) (match-end 0)
+                           'face 'font-lock-variable-name-face))))
   nil)
 
 (eval-after-load 'php-mode

--- a/tests/issue-253.php
+++ b/tests/issue-253.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * GitHub Issue:    https://github.com/ejmr/php-mode/issues/253
+ *
+ * Highlighting fails after a string with too many escaped quotes
+ */
+
+class A {
+    function a($x = null) {
+        $this->x = $x;
+    }
+
+    $STRING = '\'\'\'';
+
+    function b($x = null) {
+        $this->x = $x;
+    }
+}


### PR DESCRIPTION
CC: @redbeardcreator

This is related to #253.

#### before
![before](https://cloud.githubusercontent.com/assets/554281/7907091/b0070756-086f-11e5-9aa1-e115bfd83427.png)

#### after
![after](https://cloud.githubusercontent.com/assets/554281/7907092/b2f09fb8-086f-11e5-9197-3fc2daac667a.png)


( I suppose this is not smart solution. However I don't know smart answer :-( )