### PR TITLE
PHP 7.0 Syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ Experimental and In-Progress Features
 
 Daniel Haxney began incorporating CC Mode, and now the task is carried on by Jorys Steyn.  The features are not complete but are usable.  To test this out you can switch to the `cc-mode-conversion` branch.  Please report all feedback [on this thread](https://github.com/ejmr/php-mode/issues/66#issuecomment-53677111)
 
+### PHP 7 Support ###
+
+At this time of writing PHP 7 is currently on its fourth Release Candidate.  PHP Mode supports the following features and changes from PHP 7:
+
+1. Type-hints for return values in functions and methods receive syntax highlighting in the same way as type-hints for function and method parameters.
+
+2. PHP Mode treats `yield from` as keyword in the same way it already does for a sole `yield`.
+
+3. It recognizes `strict_types` as a special declaration in the same way as `ticks`.
+
 
 Features
 --------

--- a/php-mode.el
+++ b/php-mode.el
@@ -550,6 +550,7 @@ PHP does not have an \"enum\"-like keyword."
     "var"
     "xor"
     "yield"
+    "yield from"
 
     ;; Below keywords are technically not reserved keywords, but
     ;; threated no differently by php-mode from actual reserved

--- a/php-mode.el
+++ b/php-mode.el
@@ -11,7 +11,7 @@
 (defconst php-mode-version-number "1.17.0"
   "PHP Mode version number.")
 
-(defconst php-mode-modified "2015-09-17"
+(defconst php-mode-modified "2015-10-01"
   "PHP Mode build date.")
 
 ;;; License
@@ -1405,6 +1405,9 @@ a completion list."
      (,(concat (regexp-opt (c-lang-const c-class-decl-kwds php))
                " \\(\\sw+\\)")
       1 font-lock-type-face)
+
+     ;; Highlight return types in functions and methods.
+     ("function.+:\\s-?\\(\\sw+\\)" 1 font-lock-type-face)
 
      ;; While c-opt-cpp-* highlights the <?php opening tags, it is not
      ;; possible to make it highlight short open tags and closing tags

--- a/php-mode.el
+++ b/php-mode.el
@@ -559,6 +559,7 @@ PHP does not have an \"enum\"-like keyword."
     ;;; declare directives:
     "encoding"
     "ticks"
+    "strict_types"
 
     ;;; self for static references:
     "self"

--- a/tests/language-constructs.php
+++ b/tests/language-constructs.php
@@ -77,3 +77,4 @@ var;
 while;
 xor;
 yield;
+yield from;


### PR DESCRIPTION
I am working on a few patches to add support for some new syntax that is part of PHP 7.0, now that the first alpha is available.  Additional things I want to add before merging this is support for the new `??` operator and group namespace declarations.  I would also appreciate it if anyone double-checks these patches for errors before I merge anything.