### PR TITLE
Remove font-lock-maximum-decoration setting

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -1001,8 +1001,7 @@ PHP heredoc."
     (set (make-local-variable 'syntax-propertize-function)
          #'php-syntax-propertize-function))
 
-  (setq font-lock-maximum-decoration t
-        imenu-generic-expression php-imenu-generic-expression)
+  (setq imenu-generic-expression php-imenu-generic-expression)
 
   ;; PHP vars are case-sensitive
   (setq case-fold-search t)


### PR DESCRIPTION
Because it's default value is 't.
This is related to #270