### PR TITLE
Improve php-ext package

### DIFF
--- a/skeleton/php-ext.el
+++ b/skeleton/php-ext.el
@@ -28,6 +28,11 @@
 
 ;; Math functions
 
+(defvar php-ext-path
+  (if load-file-name
+      (file-name-directory load-file-name)
+    default-directory))
+
 (load (concat php-ext-path "php-math.el"))
 
 ;; Control Structures

--- a/skeleton/php-ext.el
+++ b/skeleton/php-ext.el
@@ -1,3 +1,5 @@
+;;; php-ext.el --- PHP skeleton templates
+
 ;; Copyright (C) 2015  David Arroyo Menéndez
 
 ;; Author: David Arroyo Menéndez <davidam@gnu.org>
@@ -126,3 +128,6 @@
   '(setq value (skeleton-read "Value? "))
   "define(\"" variable "\",\"" value "\");")
 
+(provide 'php-ext)
+
+;;; php-ext.el ends here

--- a/skeleton/php-ext.el
+++ b/skeleton/php-ext.el
@@ -17,7 +17,7 @@
 
 ;; You should have received a copy of the GNU General Public License
 ;; along with GNU Emacs; see the file COPYING.  If not, write to
-;; the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, 
+;; the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
 ;; Boston, MA 02110-1301 USA,
 
 ;; To install php-ext.el:
@@ -61,10 +61,10 @@
 ;; Handling Variables
 ;; http://php.net/manual/en/ref.var.php
 ;; file:///usr/share/doc/php-doc/html/ref.var.html
- 
+
 (load (concat php-ext-path "php-var.el"))
 
-;; DOM 
+;; DOM
 ;; More see file:///usr/share/doc/php-doc/html/book.dom.html
 
 (load (concat php-ext-path "php-dom.el"))
@@ -113,7 +113,7 @@
   ""
   '(setq function (skeleton-read "Function name? ")) \n
   '(setq argument (skeleton-read "Argument? ")) \n
-  > "function " function "(" argument 
+  > "function " function "(" argument
   ( "Another argument? %s: "
     > ", " str )
   > ") {" \n

--- a/skeleton/php-ext.el
+++ b/skeleton/php-ext.el
@@ -21,9 +21,8 @@
 ;; Boston, MA 02110-1301 USA,
 
 ;; To install php-ext.el:
-;; You can adapt the next lines in your .emacs
-;; (setq php-ext-path "~/git/php-ext-el")
-;; (load (concat php-ext-path "php-ext.el"))
+
+;; (require 'php-ext)
 
 ;; Description:
 ;; Php ext is some skeleton templates for extend php-mode


### PR DESCRIPTION
- Set php-ext-path by default
- Fix as Emacs Lisp package
- Delete trailing spaces

This is related to #273 