### PR TITLE
Support PSR-5(Draft) style tag (annotation)

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -1462,7 +1462,7 @@ The output will appear in the buffer *PHP*."
 (defface php-annotations-annotation-face '((t . (:inherit font-lock-constant-face)))
   "Face used to highlight annotations.")
 
-(defconst php-annotations-re "\\(\\s-\\|{\\)\\(@[[:alpha:]]+\\)")
+(defconst php-annotations-re "\\(\\s-\\|{\\)\\(@[-\\[:alpha:]]+\\)")
 
 (defmacro php-annotations-inside-comment-p (pos)
   "Return non-nil if POS is inside a comment."


### PR DESCRIPTION
see [PSR-5: PHPDoc 5.3.1. Tag Name](https://github.com/phpDocumentor/fig-standards/blob/master/proposed/phpdoc.md#531-tag-name)

Some processor uses the tag of this style.

* phpDocumentor - [`@property-read`](https://phpdoc.org/docs/latest/references/phpdoc/tags/property-read.html) and [`@property-write`](https://phpdoc.org/docs/latest/references/phpdoc/tags/property-write.html)
* [2. Doctrine Annotations — Doctrine Common 2.1 documentation](http://doctrine-common.readthedocs.org/en/latest/reference/annotations.html)
