### PR TITLE
Workaround for Emacs 25

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -1083,7 +1083,11 @@ PHP heredoc."
   (set (make-local-variable 'defun-prompt-regexp)
        "^\\s-*function\\s-+&?\\s-*\\(\\(\\sw\\|\\s_\\)+\\)\\s-*")
   (set (make-local-variable 'add-log-current-defun-header-regexp)
-       php-beginning-of-defun-regexp))
+       php-beginning-of-defun-regexp)
+
+  (when (>= emacs-major-version 25)
+    (php-syntax-propertize-function (point-min) (point-max))))
+
 
 ;; Define function name completion function
 (defvar php-completion-table nil


### PR DESCRIPTION
We expect that php-syntax-propertize-function is called one time when opening
php file. Before emacs 25, it is called. However Emacs 25 optimizes for reducing
calling syntax-propertize-function and it is not called at opening php file. So
php-mode calls it explicitly in php-mode function.

This is related to #279.