### PR TITLE
Drop Emacs 23 support

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -32,8 +32,7 @@
 
 (require 'php-mode)
 (require 'ert)
-(eval-when-compile
-  (require 'cl))
+(require 'cl-lib)
 
 ;; Work around bug #14325
 ;; <http://debbugs.gnu.org/cgi/bugreport.cgi?bug=14325>.
@@ -51,29 +50,34 @@
 (defvar php-mode-test-magic-regexp "###php-mode-test### \\((.+)\\)"
   "Regexp which identifies a magic comment.")
 
+;; cl-letf does not work for global function on Emacs 24.3 or lower versions
+(when (and (= emacs-major-version 24) (<= emacs-minor-version 3))
+  (defun indent ()))
+
 (defun php-mode-test-process-magics ()
   "Process the test directives in the current buffer.
 These are the ###php-mode-test### comments. Valid magics are
 listed in `php-mode-test-valid-magics'; no other directives will
 be processed."
-  (flet ((indent (offset) (equal (current-indentation) offset)))
+  (cl-letf (((symbol-function 'indent)
+             (lambda (offset) (equal (current-indentation) offset))))
     (let (directives answers)
-     (save-excursion
-       (goto-char (point-min))
-       (while (re-search-forward php-mode-test-magic-regexp nil t)
-         (setq directives (read (buffer-substring (match-beginning 1)
-                                                  (match-end 1))))
-         (setq answers
-               (append (mapcar (lambda (curr)
-                                 (let ((fn (car curr))
-                                       (args (mapcar 'eval (cdr-safe curr))))
-                                   (if (memq fn php-mode-test-valid-magics)
-                                       (apply fn args))))
-                               directives)
-                       answers))))
-     answers)))
+      (save-excursion
+        (goto-char (point-min))
+        (while (re-search-forward php-mode-test-magic-regexp nil t)
+          (setq directives (read (buffer-substring (match-beginning 1)
+                                                   (match-end 1))))
+          (setq answers
+                (append (mapcar (lambda (curr)
+                                  (let ((fn (car curr))
+                                        (args (mapcar 'eval (cdr-safe curr))))
+                                    (if (memq fn php-mode-test-valid-magics)
+                                        (apply fn args))))
+                                directives)
+                        answers))))
+      answers)))
 
-(defmacro* with-php-mode-test ((file &key style indent magic custom) &rest body)
+(cl-defmacro with-php-mode-test ((file &key style indent magic custom) &rest body)
   "Set up environment for testing `php-mode'.
 Execute BODY in a temporary buffer containing the contents of
 FILE, in `php-mode'. Optional keyword `:style' can be used to set
@@ -96,7 +100,7 @@ run with specific customizations set."
      (insert-file-contents (expand-file-name ,file php-mode-test-dir))
      (php-mode)
      (font-lock-fontify-buffer)
-     ,(case style
+     ,(cl-case style
         (pear '(php-enable-pear-coding-style))
         (drupal '(php-enable-drupal-coding-style))
         (wordpress '(php-enable-wordpress-coding-style))
@@ -109,8 +113,8 @@ run with specific customizations set."
      ,(if indent
           '(indent-region (point-min) (point-max)))
      ,(if magic
-          '(should (reduce (lambda (l r) (and l r))
-                           (php-mode-test-process-magics))))
+          '(should (cl-reduce (lambda (l r) (and l r))
+                              (php-mode-test-process-magics))))
      (goto-char (point-min))
      (let ((case-fold-search nil))
        ,@body)))


### PR DESCRIPTION
Emacs 23 is too old and Emacs 25 will be released soon. And it is difficult to compile it on modern environment and it makes maintenance difficult.

This is related to #262, 