### PR TITLE
make test: allow custom TMPDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ clean:
 test:
 	make clean
 	make all
-	$(EMACS) -Q -batch -L . -l php-mode-test.el -f ert-run-tests-batch-and-exit
+	$(EMACS) -Q -batch -L . -l php-mode-test.el \
+		--eval "(setq temporary-file-directory \"$$TMPDIR\")" \
+		-f ert-run-tests-batch-and-exit
 
 .PHONY: all clean test


### PR DESCRIPTION
This might be a bit of a niche use-case, but [Homebrew](https://github.com/Homebrew/homebrew-emacs) does builds and tests in a sandbox so it'd be nice to be able to restrict the writes that happen during the tests to within that sandbox.