### PR TITLE
Retain the modification state on mode activation

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -605,6 +605,13 @@ style from Drupal."
     (search-forward "$that")
     (should-not (eq 'font-lock-constant-face (get-text-property (- (point) 1) 'face)))))
 
+(ert-deftest php-mode-test-issue-307 ()
+  "Activating php-mode should not mark the buffer as modified."
+  (with-php-mode-test ("issue-307.php")
+    (set-buffer-modified-p nil)
+    (php-mode)
+    (should-not (buffer-modified-p))))
+
 ;;; php-mode-test.el ends here
 
 ;; Local Variables:

--- a/php-mode.el
+++ b/php-mode.el
@@ -1061,7 +1061,8 @@ PHP heredoc."
        php-beginning-of-defun-regexp)
 
   (when (>= emacs-major-version 25)
-    (php-syntax-propertize-function (point-min) (point-max))))
+    (with-silent-modifications
+      (php-syntax-propertize-function (point-min) (point-max)))))
 
 
 ;; Define function name completion function

--- a/tests/issue-307.php
+++ b/tests/issue-307.php
@@ -1,0 +1,3 @@
+<?php
+
+// It's the apostrophe.


### PR DESCRIPTION
Since commit 86eab80 php-mode calls php-syntax-propertize-function on
mode activation in emacs 25. This commit wraps the call in the
with-silent-modifications macro so the modification state is retained,
just like how emacs' syntax.el calls syntax-propertize functions.

Resolves issue #307.