### PR TITLE
Fix failing test case on emacs 25.1 pretest

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -227,7 +227,7 @@ style from Drupal."
    ("issue-53.php")
    (search-forward "return $this->bar;")
    ;; the file written to has no significance, only the buffer
-   (let ((tmp-filename (make-temp-name temporary-file-directory)))
+   (let ((tmp-filename (concat (make-temp-name temporary-file-directory) ".php")))
      (dolist (mode '(pear wordpress symfony2))
        (php-mode-custom-coding-style-set 'php-mode-coding-style 'drupal)
        (php-mode-custom-coding-style-set 'php-mode-coding-style mode)


### PR DESCRIPTION
In emacs 25, an active major mode will not be active after calling
write-file with a filename that doesn't match the major modes
auto-mode-alist.

Before: https://travis-ci.org/jorissteyn/php-mode/builds/146990813
After: https://travis-ci.org/jorissteyn/php-mode/builds/147005227