### PR TITLE
 Fix indentation after function with return type

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -612,6 +612,10 @@ style from Drupal."
     (php-mode)
     (should-not (buffer-modified-p))))
 
+(ert-deftest php-mode-test-issue-310 ()
+  "Proper indentation after function with return type."
+  (with-php-mode-test ("issue-310.php" :indent t :magic t)))
+
 ;;; php-mode-test.el ends here
 
 ;; Local Variables:

--- a/php-mode.el
+++ b/php-mode.el
@@ -93,6 +93,23 @@
   (if (and (= emacs-major-version 24) (>= emacs-minor-version 4))
     (require 'cl)))
 
+;; Work around https://github.com/ejmr/php-mode/issues/310.
+;;
+;; In emacs 24.4 and 24.5, lines after functions with a return type
+;; are incorrectly analyzed as member-init-cont.
+;;
+;; Before emacs 24.4, c member initializers are not supported this
+;; way. Starting from emacs 25.1, cc-mode only detects member
+;; initializers when the major mode is c++-mode.
+(eval-and-compile
+  (if (and (= emacs-major-version 24) (or (= emacs-minor-version 4)
+                                          (= emacs-minor-version 5)))
+      (defun c-back-over-member-initializers ()
+        ;; Override of cc-engine.el, cc-mode in emacs 24.4 and 24.5 are too
+        ;; optimistic in recognizing c member initializers. Since we don't
+        ;; need it in php-mode, just return nil.
+        nil)))
+
 
 ;; Local variables
 ;;;###autoload

--- a/tests/issue-310.php
+++ b/tests/issue-310.php
@@ -1,0 +1,6 @@
+<?php
+
+function a() : string {
+    return 'world';
+}
+echo 'hello'; // ###php-mode-test### ((indent 0))


### PR DESCRIPTION
Work around zealous detection of c member initializers in cc-mode < emacs 25.1. See #310.