### PR TITLE
Fix #314, activating php-mode moves point to last apostrophe

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -612,6 +612,13 @@ style from Drupal."
     (php-mode)
     (should-not (buffer-modified-p))))
 
+(ert-deftest php-mode-test-issue-314 ()
+  "Activating php-mode should not move point."
+  (with-php-mode-test ("issue-314.php")
+    (let ((orig-point (point)))
+      (php-mode)
+      (should (eq (point) orig-point)))))
+
 (ert-deftest php-mode-test-issue-310 ()
   "Proper indentation after function with return type."
   (with-php-mode-test ("issue-310.php" :indent t :magic t)))

--- a/php-mode.el
+++ b/php-mode.el
@@ -931,11 +931,12 @@ the string HEREDOC-START."
   (while (and (< (point) end)
               (re-search-forward php-heredoc-start-re end t))
     (php-heredoc-syntax))
-  (goto-char start)
-  (while (re-search-forward "['\"]" end t)
-    (when (php-in-comment-p)
-      (c-put-char-property (match-beginning 0)
-                           'syntax-table (string-to-syntax "_")))))
+  (save-excursion
+    (goto-char start)
+    (while (re-search-forward "['\"]" end t)
+      (when (php-in-comment-p)
+        (c-put-char-property (match-beginning 0)
+                             'syntax-table (string-to-syntax "_"))))))
 
 (defun php-heredoc-syntax ()
   "Mark the boundaries of searched heredoc."

--- a/tests/issue-314.php
+++ b/tests/issue-314.php
@@ -1,0 +1,3 @@
+<?php
+
+// It's the apostrophe.


### PR DESCRIPTION
This behavior was regressed by #307 because `re-search-forward` moves point. I added a `save-excursion` around that piece of code and a brief test.

The test PHP file should probably contain more varied code to catch future regressions that might happen based on other characters, but for now I targeted this specific issue.

This is my first php-mode merge request so let me know if I can make it more friendly in any way.