### PR TITLE
Modify font-lock regexp for function names

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -12,7 +12,7 @@
 (defconst php-mode-version-number "1.17.0"
   "PHP Mode version number.")
 
-(defconst php-mode-modified "2016-08-22"
+(defconst php-mode-modified "2016-08-31"
   "PHP Mode build date.")
 
 ;;; License
@@ -1354,7 +1354,7 @@ a completion list."
      ("\\(\\$\\|->\\)\\([a-zA-Z0-9_]+\\)" 2 font-lock-variable-name-face)
 
      ;; Highlight function/method names
-     ("\\<function\\s-+&?\\(\\sw+\\)\\s-*(" 1 font-lock-function-name-face)
+     ("\\<function\\s-+&?\\(\\(?:\\sw\\|\\s_\\)+\\)\\s-*(" 1 font-lock-function-name-face)
 
      ;; The dollar sign should not get a variable-name face, below
      ;; pattern resets the face to default in case cc-mode sets the
@@ -1408,7 +1408,7 @@ a completion list."
       1 font-lock-type-face)
 
      ;; Highlight return types in functions and methods.
-     ("function.+:\\s-?\\(\\sw+\\)" 1 font-lock-type-face)
+     ("function.+:\\s-?\\(\\(?:\\sw\\|\\s_\\)+\\)" 1 font-lock-type-face)
 
      ;; While c-opt-cpp-* highlights the <?php opening tags, it is not
      ;; possible to make it highlight short open tags and closing tags


### PR DESCRIPTION
`php-font-lock-keywords-3` definition is different from [`php-create-regexp-for-method`](https://github.com/ejmr/php-mode/blob/10e2e70eaa4b28603935c271c9e2806fd0a6bfc9/php-mode.el#L199-L219) (`\\sw+` and `\\(?:\\sw\\|\\s_\\)`).
