### PR TITLE
Set '$' as 'prefix class' instead of 'word class'

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -990,6 +990,7 @@ PHP heredoc."
   (modify-syntax-entry ?\"   "\"" php-mode-syntax-table)
   (modify-syntax-entry ?#    "< b" php-mode-syntax-table)
   (modify-syntax-entry ?\n   "> b" php-mode-syntax-table)
+  (modify-syntax-entry ?$    "'" php-mode-syntax-table)
 
   (set (make-local-variable 'syntax-propertize-via-font-lock)
        '(("\\(\"\\)\\(\\\\.\\|[^\"\n\\]\\)*\\(\"\\)" (1 "\"") (3 "\""))


### PR DESCRIPTION
This is same as 'sh-mode' and 'ruby-mode'.

This is related to #320.
CC: @mallt