### PR TITLE
Impl PHPDoc font-lock mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,12 +127,22 @@ The key command `C-c C-f` will search the PHP website for documentation on the w
 
 The command `php-send-region`, which is bound to `C-c C-r` by default, will execute the selected region of PHP code.  In conjunction with the Emacs command `C-x h` you can use this to execute an entire file.  Any output will appear in a buffer called `*PHP*`.
 
-### Annotation Highlighting ###
+### PHPDoc Tag / Annotation Highlighting ###
 
-Projects like [Symfony](http://symfony.com/) use annotations in comments.  For example, here is code from their website:
+PHPDoc is a documentation format similar to [JavaDoc](https://en.wikipedia.org/wiki/Javadoc).
+
+There are `@param`, `@return`, `@var`... etc in the notation called **tag**, look at [list of tags defined by phpDocumentor2](https://phpdoc.org/docs/latest/references/phpdoc/tags/index.html).  (These tags are compatible with static type checkers like PhpStorm and [Phan](https://github.com/etsy/phan).)
+
+In addition, it also partially supports notation called **annotation**.  Annotation has a slightly different grammar from tag, and the example is `@Annotation(attr1="vvv", attr2="zzz")`.
+
+[Symfony](http://symfony.com/) project and [Go! AOP](https://github.com/goaop/framework) and some projects/frameworks use annotation grammer based on [Doctrine Annotations](http://docs.doctrine-project.org/projects/doctrine-common/en/latest/reference/annotations.html).
 
 ```php
 /**
+ * Summary of Product class
+ *
+ * @copyright 2112 John Doe
+ * @license https://spdx.org/licenses/Apache-2.0.html Apache License 2.0
  * @ORM\Entity
  * @ORM\Table(name="product")
  */
@@ -163,6 +173,8 @@ class Product
 ```
 
 The annotations are the lines that begin with the `@` character, and PHP Mode will give these special highlighting to help them stand out.
+
+PHP Mode has not fully supported [PSR-5: PHPDoc (Draft)](https://github.com/phpDocumentor/fig-standards/blob/master/proposed/phpdoc.md) yet.
 
 ### Coding Styles ###
 

--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -126,9 +126,9 @@ run with specific customizations set."
   "Annotation highlighting."
   (with-php-mode-test ("issue-8.php")
     (search-forward "@ORM")
-    (should (eq
+    (should (equal
              (get-text-property (match-beginning 0) 'face)
-             'php-annotations-annotation-face))))
+             '(php-annotations-annotation-face font-lock-doc-face)))))
 
 (ert-deftest php-mode-test-issue-9 ()
   "Single quote in text in HTML misinterpreted.
@@ -588,16 +588,16 @@ style from Drupal."
     (cl-loop for i from 1 to 3
              do
              (progn
-               (should (eq (get-text-property (match-beginning i) 'face)
-                           'php-annotations-annotation-face))
-               (should (eq (get-text-property (1- (match-end i)) 'face)
-                           'php-annotations-annotation-face))))
+               (should (equal (get-text-property (match-beginning i) 'face)
+                              '(php-annotations-annotation-face font-lock-doc-face)))
+               (should (equal (get-text-property (1- (match-end i)) 'face)
+                              '(php-annotations-annotation-face font-lock-doc-face)))))
 
     (search-forward "@property-read")
-    (should (eq (get-text-property (match-beginning 0) 'face)
-                'php-annotations-annotation-face))
-    (should (eq (get-text-property (1- (match-end 0)) 'face)
-                'php-annotations-annotation-face))))
+    (should (equal (get-text-property (match-beginning 0) 'face)
+                   '(php-annotations-annotation-face font-lock-doc-face)))
+    (should (equal (get-text-property (1- (match-end 0)) 'face)
+                   '(php-annotations-annotation-face font-lock-doc-face)))))
 
 (ert-deftest php-mode-test-issue-305 ()
   "Test highlighting variables which contains 'this' or 'that'."

--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -379,6 +379,17 @@ style from Drupal."
                 'font-lock-comment-face))
 
     ;; Class level doc-comment
+    (search-forward-regexp "{@internal \\(Description\\)}")
+    (should (equal (get-text-property (match-beginning 0) 'face)
+                   '(php-annotations-annotation-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-beginning 1) 'face)
+                   '(font-lock-string-face php-annotations-annotation-face font-lock-doc-face)))
+
+    (should (equal (get-text-property (1- (match-end 0)) 'face)
+                   '(php-annotations-annotation-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-end 0) 'face)
+                   'font-lock-doc-face))
+
     (search-forward-regexp "@property\\(-read\\)")
     (should (equal (get-text-property (match-beginning 0) 'face)
                    '(php-annotations-annotation-face font-lock-doc-face)))

--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -396,7 +396,7 @@ style from Drupal."
     (should (equal (get-text-property (match-beginning 0) 'face)
                    '(php-annotations-annotation-face font-lock-doc-face)))
     (should (equal (get-text-property (match-beginning 1) 'face)
-                   '(font-lock-type-face font-lock-doc-face)))
+                   '(font-lock-type-face font-lock-string-face font-lock-doc-face)))
     (should (equal (get-text-property (match-beginning 2) 'face)
                    'font-lock-doc-face))
 

--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -339,6 +339,85 @@ style from Drupal."
   "Closure indentation."
   (with-php-mode-test ("issue-145.php" :indent t)))
 
+(ert-deftest php-mode-test-comments ()
+  "Proper highlighting for comments and doc-blocks."
+  (with-php-mode-test ("comments.php")
+    (search-forward "/**")
+    (should (eq (get-text-property (match-beginning 0) 'face)
+                'font-lock-doc-face))
+
+    (search-forward "@copyright")
+    (should (equal (get-text-property (match-beginning 0) 'face)
+                   '(php-annotations-annotation-face font-lock-doc-face)))
+
+    (search-forward-regexp "// \\(@annotation This is NOT annotation. 1\\)")
+    (should (eq (get-text-property (match-beginning 0) 'face)
+                'font-lock-comment-delimiter-face))
+    (should (eq (get-text-property (match-beginning 1) 'face)
+                'font-lock-comment-face))
+
+    (search-forward-regexp "\\* \\(@annotation This is NOT annotation. 2\\)")
+    (should (eq (get-text-property (match-beginning 0) 'face)
+                'font-lock-comment-face))
+    (should (eq (get-text-property (match-beginning 1) 'face)
+                'font-lock-comment-face))
+
+    ;; Comment outed doc-block
+    (search-forward "/**")
+    (should (eq (get-text-property (match-beginning 0) 'face)
+                'font-lock-comment-face))
+
+    (search-forward-regexp "\\* \\(@annotation This is NOT annotation. 3\\)")
+    (should (equal (get-text-property (match-beginning 0) 'face)
+                   'font-lock-comment-face))
+
+    (should (equal (get-text-property (match-beginning 1) 'face)
+                   'font-lock-comment-face))
+
+    (search-forward "class CommentOuted")
+    (should (eq (get-text-property (match-beginning 0) 'face)
+                'font-lock-comment-face))
+
+    ;; Class level doc-comment
+    (search-forward-regexp "@property\\(-read\\)")
+    (should (equal (get-text-property (match-beginning 0) 'face)
+                   '(php-annotations-annotation-face font-lock-doc-face)))
+
+    (should (equal (get-text-property (match-beginning 1) 'face)
+                   '(php-annotations-annotation-face font-lock-doc-face)))
+
+    (search-forward-regexp "@ORM\\(\\\\Table\\)")
+    (should (equal (get-text-property (match-beginning 0) 'face)
+                   '(php-annotations-annotation-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-beginning 1) 'face)
+                   '(php-annotations-annotation-face font-lock-doc-face)))
+
+    (search-forward-regexp "@var \\(string\\) \\(sample property doc-comment\\)")
+    (should (equal (get-text-property (match-beginning 0) 'face)
+                   '(php-annotations-annotation-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-beginning 1) 'face)
+                   '(font-lock-type-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-beginning 2) 'face)
+                   'font-lock-doc-face))
+
+    (search-forward-regexp "// \\(comment in after code\\)")
+    (should (eq (get-text-property (match-beginning 0) 'face)
+                'font-lock-comment-delimiter-face))
+    (should (eq (get-text-property (match-beginning 1) 'face)
+                'font-lock-comment-face))
+
+    (search-forward-regexp "// \\(one-line comment\\)")
+    (should (eq (get-text-property (match-beginning 0) 'face)
+                'font-lock-comment-delimiter-face))
+    (should (eq (get-text-property (match-beginning 1) 'face)
+                'font-lock-comment-face))
+
+    (search-forward-regexp "// \\(@annotation This is NOT annotation. 4\\)")
+    (should (eq (get-text-property (match-beginning 0) 'face)
+                'font-lock-comment-delimiter-face))
+    (should (eq (get-text-property (match-beginning 1) 'face)
+                'font-lock-comment-face))))
+
 (ert-deftest php-mode-test-constants ()
   "Proper highlighting for constants."
   (custom-set-variables '(php-extra-constants (quote ("extraconstant"))))

--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -417,6 +417,28 @@ style from Drupal."
     (should (eq (get-text-property (match-beginning 1) 'face)
                 'font-lock-comment-face))
 
+    (search-forward-regexp "@var \\(string\\)|\\(bool\\)|\\(array\\)\\([[]]\\)|\\(ArrayObject\\) \\*/$")
+    (should (equal (get-text-property (match-beginning 0) 'face) ;; matches `@'
+                   '(php-annotations-annotation-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `s'
+                   '(font-lock-type-face font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-end 1) 'face)       ;; matches `|'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-beginning 2) 'face) ;; matches `b'
+                   '(font-lock-type-face font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-end 2) 'face)       ;; matches `|'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-beginning 3) 'face) ;; matches `a'
+                   '(font-lock-type-face font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-beginning 4) 'face) ;; matches `['
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-end 4) 'face)       ;; matches `|'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-beginning 5) 'face) ;; matches `A'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-end 5) 'face)       ;; matches ` '
+                   ' font-lock-doc-face))
+
     (search-forward-regexp "// \\(one-line comment\\)")
     (should (eq (get-text-property (match-beginning 0) 'face)
                 'font-lock-comment-delimiter-face))

--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -349,6 +349,10 @@ style from Drupal."
     (search-forward "@copyright")
     (should (equal (get-text-property (match-beginning 0) 'face)
                    '(php-annotations-annotation-face font-lock-doc-face)))
+    (search-forward-regexp "@link +\\(https://github.com/ejmr/php-mode\\)")
+    (should (equal (get-text-property (match-beginning 1) 'face)
+                   '(link font-lock-doc-face)))
+
 
     (search-forward-regexp "// \\(@annotation This is NOT annotation. 1\\)")
     (should (eq (get-text-property (match-beginning 0) 'face)

--- a/php-mode.el
+++ b/php-mode.el
@@ -1339,7 +1339,7 @@ a completion list."
      0 'php-annotations-annotation-face prepend nil)
     (,(concat "\\s-\\("
               (regexp-opt (c-lang-const c-primitive-type-kwds php))
-              "\\(?:\\[]\\)?\\)\\s-")
+              "\\(?:\\[]\\)?\\)\\(\\s-\\|$\\)")
      1 font-lock-type-face prepend nil)
     (,(rx "$" (in "A-Za-z_") (* (in "0-9A-Za-z_")))
      0 font-lock-variable-name-face prepend nil)

--- a/php-mode.el
+++ b/php-mode.el
@@ -1342,6 +1342,7 @@ a completion list."
 
 (defconst php-font-lock-keywords-3
   (append
+   javadoc-font-lock-keywords
    ;; php-mode patterns *before* cc-mode:
    ;;  only add patterns here if you want to prevent cc-mode from applying
    ;;  a different face.

--- a/php-mode.el
+++ b/php-mode.el
@@ -1334,6 +1334,16 @@ a completion list."
   (interactive)
   (browse-url php-manual-url))
 
+(defconst php-phpdoc-font-lock-doc-comments
+  `((,(rx "{@" (+ (or "-" alpha)) (syntax whitespace) (* (not (any "}"))) "}") ; "{@foo ...}" markup.
+     0 ,c-doc-markup-face-name prepend nil)
+    (,(concat "\\s-\\(" (regexp-opt (c-lang-const c-primitive-type-kwds php)) "\\(?:\\[]\\)?\\)\\s-")
+     1 font-lock-type-face prepend nil)
+    (,(rx "$" (in "A-Za-z_") (* (in "0-9A-Za-z_")))
+     0 font-lock-variable-name-face prepend nil)
+    ("^\\(?:/\\*\\)?\\(?:\\s \\|\\*\\)*\\(@[A-Za-z][-A-Za-z\\]*\\)" ; "@foo ..." markup.
+     1 ,c-doc-markup-face-name prepend nil)))
+
 (defconst php-font-lock-keywords-1 (c-lang-const c-matchers-1 php)
   "Basic highlighting for PHP mode.")
 
@@ -1342,7 +1352,9 @@ a completion list."
 
 (defconst php-font-lock-keywords-3
   (append
-   javadoc-font-lock-keywords
+   `((,(lambda (limit)
+	(c-font-lock-doc-comments "/\\*\\*" limit
+	  php-phpdoc-font-lock-doc-comments))))
    ;; php-mode patterns *before* cc-mode:
    ;;  only add patterns here if you want to prevent cc-mode from applying
    ;;  a different face.

--- a/php-mode.el
+++ b/php-mode.el
@@ -1357,6 +1357,8 @@ a completion list."
               (regexp-opt php-phpdoc-type-keywords)
               "\\)")
      1 font-lock-type-face prepend nil)
+    ("https?://[^\\S\n]+"
+     0 'link prepend nil)
     ("^\\(?:/\\*\\)?\\(?:\\s \\|\\*\\)*\\(@[[:alpha:]][-[:alpha:]\\]*\\)" ; "@foo ..." markup.
      1 'php-annotations-annotation-face prepend nil)))
 

--- a/php-mode.el
+++ b/php-mode.el
@@ -603,7 +603,7 @@ but only if the setting is enabled"
 (c-add-style
  "php"
  '((c-basic-offset . 4)
-   (c-doc-comment-style . javadoc)
+   ;;(c-doc-comment-style . php-phpdoc)
    (c-offsets-alist . ((arglist-close . php-lineup-arglist-close)
                        (arglist-cont . (first php-lineup-cascaded-calls 0))
                        (arglist-cont-nonempty . (first php-lineup-cascaded-calls c-lineup-arglist))
@@ -1346,6 +1346,11 @@ a completion list."
     ("^\\(?:/\\*\\)?\\(?:\\s \\|\\*\\)*\\(@[[:alpha:]][-[:alpha:]\\]*\\)" ; "@foo ..." markup.
      1 'php-annotations-annotation-face prepend nil)))
 
+(defvar php-phpdoc-font-lock-keywords
+  `((,(lambda (limit)
+	(c-font-lock-doc-comments "/\\*\\*" limit
+	  php-phpdoc-font-lock-doc-comments)))))
+
 (defconst php-font-lock-keywords-1 (c-lang-const c-matchers-1 php)
   "Basic highlighting for PHP mode.")
 
@@ -1354,9 +1359,7 @@ a completion list."
 
 (defconst php-font-lock-keywords-3
   (append
-   `((,(lambda (limit)
-	(c-font-lock-doc-comments "/\\*\\*" limit
-	  php-phpdoc-font-lock-doc-comments))))
+   php-phpdoc-font-lock-keywords
    ;; php-mode patterns *before* cc-mode:
    ;;  only add patterns here if you want to prevent cc-mode from applying
    ;;  a different face.

--- a/php-mode.el
+++ b/php-mode.el
@@ -1476,24 +1476,6 @@ The output will appear in the buffer *PHP*."
 (defface php-annotations-annotation-face '((t . (:inherit font-lock-constant-face)))
   "Face used to highlight annotations.")
 
-(defconst php-annotations-re "\\(\\s-\\|{\\)\\(@[-\\[:alpha:]]+\\)")
-
-(defmacro php-annotations-inside-comment-p (pos)
-  "Return non-nil if POS is inside a comment."
-  `(eq (get-char-property ,pos 'face) 'font-lock-doc-face))
-
-(defun php-annotations-font-lock-find-annotation (limit)
-  (let ((match
-         (catch 'match
-           (save-match-data
-             (while (re-search-forward php-annotations-re limit t)
-               (when (php-annotations-inside-comment-p (match-beginning 0))
-                 (goto-char (match-end 0))
-                 (throw 'match (match-data))))))))
-    (when match
-      (set-match-data match)
-      t)))
-
 (defconst php-string-interpolated-variable-regexp
   "{\\$[^}\n\\\\]*\\(?:\\\\.[^}\n\\\\]*\\)*}\\|\\${\\sw+}\\|\\$\\sw+")
 
@@ -1507,9 +1489,6 @@ The output will appear in the buffer *PHP*."
 
 (eval-after-load 'php-mode
   '(progn
-     (font-lock-add-keywords
-      'php-mode
-      '((php-annotations-font-lock-find-annotation (2 'php-annotations-annotation-face t))))
      (font-lock-add-keywords
       'php-mode
       `((php-string-intepolated-variable-font-lock-find))

--- a/php-mode.el
+++ b/php-mode.el
@@ -1468,8 +1468,7 @@ The output will appear in the buffer *PHP*."
 
 (defmacro php-annotations-inside-comment-p (pos)
   "Return non-nil if POS is inside a comment."
-  `(or (eq (get-char-property ,pos 'face) 'font-lock-comment-face)
-       (eq (get-char-property ,pos 'face) 'font-lock-comment-delimiter-face)))
+  `(eq (get-char-property ,pos 'face) 'font-lock-doc-face))
 
 (defun php-annotations-font-lock-find-annotation (limit)
   (let ((match

--- a/php-mode.el
+++ b/php-mode.el
@@ -1343,8 +1343,9 @@ a completion list."
   (list "param" "property" "property-read" "property-write" "return" "var"))
 
 (defconst php-phpdoc-font-lock-doc-comments
-  `(("{@[-[:alpha:]]+\\s-[^}]*}" ; "{@foo ...}" markup.
-     0 'php-annotations-annotation-face prepend nil)
+  `(("{@[-[:alpha:]]+\\s-\\([^}]*\\)}" ; "{@foo ...}" markup.
+     (0 'php-annotations-annotation-face prepend nil)
+     (1 'font-lock-string-face prepend nil))
     (,(rx "$" (in "A-Za-z_") (* (in "0-9A-Za-z_")))
      0 font-lock-variable-name-face prepend nil)
     (,(concat "\\s-@" (regexp-opt php-phpdoc-type-tags) "\\s-+"

--- a/php-mode.el
+++ b/php-mode.el
@@ -1337,7 +1337,8 @@ a completion list."
 (defconst php-phpdoc-type-keywords
   (list "string" "integer" "int" "boolean" "bool" "float"
         "double" "object" "mixed" "array" "resource" "$this"
-        "void" "null" "callback" "false" "true" "self"))
+        "void" "null" "callback" "false" "true" "self"
+        "callable" "iterable" "number"))
 
 (defconst php-phpdoc-type-tags
   (list "param" "property" "property-read" "property-write" "return" "var"))

--- a/php-mode.el
+++ b/php-mode.el
@@ -1334,15 +1334,20 @@ a completion list."
   (interactive)
   (browse-url php-manual-url))
 
+(defconst php-phpdoc-type-keywords
+  (list "string" "integer" "int" "boolean" "bool" "float"
+        "double" "object" "mixed" "array" "resource" "$this"
+        "void" "null" "callback" "false" "true" "self"))
+
 (defconst php-phpdoc-font-lock-doc-comments
   `(("{@[-[:alpha:]]\\s-[^}]*}" ; "{@foo ...}" markup.
      0 'php-annotations-annotation-face prepend nil)
-    (,(concat "\\s-\\("
-              (regexp-opt (c-lang-const c-primitive-type-kwds php))
-              "\\(?:\\[]\\)?\\)\\(\\s-\\|$\\)")
-     1 font-lock-type-face prepend nil)
     (,(rx "$" (in "A-Za-z_") (* (in "0-9A-Za-z_")))
      0 font-lock-variable-name-face prepend nil)
+    (,(concat "\\s-\\("
+              (regexp-opt php-phpdoc-type-keywords)
+              "\\)\\(?:\\s-\\|$\\)")
+     1 font-lock-type-face prepend nil)
     ("^\\(?:/\\*\\)?\\(?:\\s \\|\\*\\)*\\(@[[:alpha:]][-[:alpha:]\\]*\\)" ; "@foo ..." markup.
      1 'php-annotations-annotation-face prepend nil)))
 

--- a/php-mode.el
+++ b/php-mode.el
@@ -1355,7 +1355,7 @@ a completion list."
      1 font-lock-string-face prepend nil)
     (,(concat "\\(?:|\\|\\s-\\)\\("
               (regexp-opt php-phpdoc-type-keywords)
-              "\\)\\(?:|\\|\\s-\\|\\[]\\|$\\)")
+              "\\)")
      1 font-lock-type-face prepend nil)
     ("^\\(?:/\\*\\)?\\(?:\\s \\|\\*\\)*\\(@[[:alpha:]][-[:alpha:]\\]*\\)" ; "@foo ..." markup.
      1 'php-annotations-annotation-face prepend nil)))

--- a/php-mode.el
+++ b/php-mode.el
@@ -603,7 +603,6 @@ but only if the setting is enabled"
 (c-add-style
  "php"
  '((c-basic-offset . 4)
-   ;;(c-doc-comment-style . php-phpdoc)
    (c-offsets-alist . ((arglist-close . php-lineup-arglist-close)
                        (arglist-cont . (first php-lineup-cascaded-calls 0))
                        (arglist-cont-nonempty . (first php-lineup-cascaded-calls c-lineup-arglist))

--- a/php-mode.el
+++ b/php-mode.el
@@ -1343,7 +1343,7 @@ a completion list."
   (list "param" "property" "property-read" "property-write" "return" "var"))
 
 (defconst php-phpdoc-font-lock-doc-comments
-  `(("{@[-[:alpha:]]\\s-[^}]*}" ; "{@foo ...}" markup.
+  `(("{@[-[:alpha:]]+\\s-[^}]*}" ; "{@foo ...}" markup.
      0 'php-annotations-annotation-face prepend nil)
     (,(rx "$" (in "A-Za-z_") (* (in "0-9A-Za-z_")))
      0 font-lock-variable-name-face prepend nil)

--- a/php-mode.el
+++ b/php-mode.el
@@ -1357,7 +1357,7 @@ a completion list."
               (regexp-opt php-phpdoc-type-keywords)
               "\\)")
      1 font-lock-type-face prepend nil)
-    ("https?://[^\\S\n]+"
+    ("https?://[^\n\t ]+"
      0 'link prepend nil)
     ("^\\(?:/\\*\\)?\\(?:\\s \\|\\*\\)*\\(@[[:alpha:]][-[:alpha:]\\]*\\)" ; "@foo ..." markup.
      1 'php-annotations-annotation-face prepend nil)))

--- a/php-mode.el
+++ b/php-mode.el
@@ -1337,7 +1337,7 @@ a completion list."
 (defconst php-phpdoc-type-keywords
   (list "string" "integer" "int" "boolean" "bool" "float"
         "double" "object" "mixed" "array" "resource" "$this"
-        "void" "null" "callback" "false" "true" "self"
+        "void" "null" "false" "true" "self" "static"
         "callable" "iterable" "number"))
 
 (defconst php-phpdoc-type-tags

--- a/php-mode.el
+++ b/php-mode.el
@@ -1335,14 +1335,16 @@ a completion list."
   (browse-url php-manual-url))
 
 (defconst php-phpdoc-font-lock-doc-comments
-  `((,(rx "{@" (+ (or "-" alpha)) (syntax whitespace) (* (not (any "}"))) "}") ; "{@foo ...}" markup.
-     0 ,c-doc-markup-face-name prepend nil)
-    (,(concat "\\s-\\(" (regexp-opt (c-lang-const c-primitive-type-kwds php)) "\\(?:\\[]\\)?\\)\\s-")
+  `(("{@[-[:alpha:]]\\s-[^}]*}" ; "{@foo ...}" markup.
+     0 'php-annotations-annotation-face prepend nil)
+    (,(concat "\\s-\\("
+              (regexp-opt (c-lang-const c-primitive-type-kwds php))
+              "\\(?:\\[]\\)?\\)\\s-")
      1 font-lock-type-face prepend nil)
     (,(rx "$" (in "A-Za-z_") (* (in "0-9A-Za-z_")))
      0 font-lock-variable-name-face prepend nil)
-    ("^\\(?:/\\*\\)?\\(?:\\s \\|\\*\\)*\\(@[A-Za-z][-A-Za-z\\]*\\)" ; "@foo ..." markup.
-     1 ,c-doc-markup-face-name prepend nil)))
+    ("^\\(?:/\\*\\)?\\(?:\\s \\|\\*\\)*\\(@[[:alpha:]][-[:alpha:]\\]*\\)" ; "@foo ..." markup.
+     1 'php-annotations-annotation-face prepend nil)))
 
 (defconst php-font-lock-keywords-1 (c-lang-const c-matchers-1 php)
   "Basic highlighting for PHP mode.")

--- a/php-mode.el
+++ b/php-mode.el
@@ -1339,14 +1339,21 @@ a completion list."
         "double" "object" "mixed" "array" "resource" "$this"
         "void" "null" "callback" "false" "true" "self"))
 
+(defconst php-phpdoc-type-tags
+  (list "param" "property" "property-read" "property-write" "return" "var"))
+
 (defconst php-phpdoc-font-lock-doc-comments
   `(("{@[-[:alpha:]]\\s-[^}]*}" ; "{@foo ...}" markup.
      0 'php-annotations-annotation-face prepend nil)
     (,(rx "$" (in "A-Za-z_") (* (in "0-9A-Za-z_")))
      0 font-lock-variable-name-face prepend nil)
-    (,(concat "\\s-\\("
+    (,(concat "\\s-@" (regexp-opt php-phpdoc-type-tags) "\\s-+"
+              "\\(" (rx (+ (? "\\") (+ (in "0-9A-Za-z")) (? "[]") (? "|"))) "\\)+"
+              "\\(?:\\s-\\|$\\)")
+     1 font-lock-string-face prepend nil)
+    (,(concat "\\(?:|\\|\\s-\\)\\("
               (regexp-opt php-phpdoc-type-keywords)
-              "\\)\\(?:\\s-\\|$\\)")
+              "\\)\\(?:|\\|\\s-\\|\\[]\\|$\\)")
      1 font-lock-type-face prepend nil)
     ("^\\(?:/\\*\\)?\\(?:\\s \\|\\*\\)*\\(@[[:alpha:]][-[:alpha:]\\]*\\)" ; "@foo ..." markup.
      1 'php-annotations-annotation-face prepend nil)))

--- a/tests/comments.php
+++ b/tests/comments.php
@@ -7,6 +7,7 @@
  * @copyright 2008 Aaron S. Hawley
  * @copyright 2011, 2012, 2013, 2014, 2015, 2016 Eric James Michael Ritz
  * @author    USAMI Kenta <tadsan@pixiv.com>
+ * @link      https://github.com/ejmr/php-mode
  */
 
 // one-line comment

--- a/tests/comments.php
+++ b/tests/comments.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * File level doc-comment
+ *
+ * @copyright 1999, 2000, 2001, 2003, 2004 Turadg Aleahmad
+ * @copyright 2008 Aaron S. Hawley
+ * @copyright 2011, 2012, 2013, 2014, 2015, 2016 Eric James Michael Ritz
+ * @author    USAMI Kenta <tadsan@pixiv.com>
+ */
+
+// one-line comment
+// @annotation This is NOT annotation.
+
+/*------------------------------------------------
+  Multi-line comment
+
+ * @annotation This is NOT annotation.
+ -------------------------------------------------*/
+
+// /**
+//  * Comment outed class implementation
+//  */
+// class CommentOuted
+// {
+// }
+
+/**
+ * Class level doc-comment
+ *
+ * Description {@internal Description} inline tag.
+ *
+ * @property-read string[] $name
+ * @ORM\Table(name="majormodes")
+ * @ORM\Entity(repositoryClass="Emacs\Repository\MajorModeRepository")
+ */
+final class SampleClass
+{
+    /** Const doc-comment */
+    const SAMPLE = 'SAMPLE';
+    /** @var string sample property doc-comment */
+    private $name;
+
+    /**
+     * @param string $name
+     */
+    public function __construct($name)
+    {
+        $this->name = $name; // comment
+
+        // one-line comment
+        // @annotation This is NOT annotation.
+    }
+}

--- a/tests/comments.php
+++ b/tests/comments.php
@@ -10,16 +10,18 @@
  */
 
 // one-line comment
-// @annotation This is NOT annotation.
+// @annotation This is NOT annotation. 1
 
 /*------------------------------------------------
   Multi-line comment
 
- * @annotation This is NOT annotation.
+ * @annotation This is NOT annotation. 2
  -------------------------------------------------*/
 
 // /**
 //  * Comment outed class implementation
+//  *
+//  * @annotation This is NOT annotation. 3
 //  */
 // class CommentOuted
 // {
@@ -46,9 +48,9 @@ final class SampleClass
      */
     public function __construct($name)
     {
-        $this->name = $name; // comment
+        $this->name = $name; // comment in after code
 
         // one-line comment
-        // @annotation This is NOT annotation.
+        // @annotation This is NOT annotation. 4
     }
 }

--- a/tests/comments.php
+++ b/tests/comments.php
@@ -50,6 +50,9 @@ final class SampleClass
     {
         $this->name = $name; // comment in after code
 
+        /** @var string|bool|array[]|ArrayObject */
+        $foo = hoge();
+
         // one-line comment
         // @annotation This is NOT annotation. 4
     }


### PR DESCRIPTION
refs #327 

~~I read `cc-font.el`.  I think this change is simple and reliable.~~

I changed the implementation policy and reimplement the mechanism for font-lock.

## Screenshots

### Before

<img width="591" alt="2017-01-26 0 30 55" src="https://cloud.githubusercontent.com/assets/822086/22299293/e29a9d4e-e366-11e6-8b40-bb2755794804.png">


### After

<img width="597" alt="2017-01-26 0 34 26" src="https://cloud.githubusercontent.com/assets/822086/22299281/db9f629a-e366-11e6-9a4c-9edb12495a7c.png">


