### PR TITLE
Fixes issue #333

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -742,6 +742,10 @@ style from Drupal."
   "Proper indentation after function with return type."
   (with-php-mode-test ("issue-310.php" :indent t :magic t)))
 
+(ert-deftest php-mode-test-issue-333 ()
+  "Do not freeze Emacs by font-lock regexp pattern."
+  (with-php-mode-test ("issue-333.php")))
+
 ;;; php-mode-test.el ends here
 
 ;; Local Variables:

--- a/php-mode.el
+++ b/php-mode.el
@@ -1349,8 +1349,7 @@ a completion list."
     (,(rx "$" (in "A-Za-z_") (* (in "0-9A-Za-z_")))
      0 font-lock-variable-name-face prepend nil)
     (,(concat "\\s-@" (regexp-opt php-phpdoc-type-tags) "\\s-+"
-              "\\(" (rx (+ (? "\\") (+ (in "0-9A-Za-z")) (? "[]") (? "|"))) "\\)+"
-              "\\(?:\\s-\\|$\\)")
+              "\\(" (rx (+ (? "\\") (+ (in "0-9A-Z_a-z")) (? "[]") (? "|"))) "\\)+")
      1 font-lock-string-face prepend nil)
     (,(concat "\\(?:|\\|\\s-\\)\\("
               (regexp-opt php-phpdoc-type-keywords)

--- a/tests/issue-333.php
+++ b/tests/issue-333.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SlowNamespace\More\Levels;
+
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+
+/**
+ * @author Charlie McMackin
+ * @see https://github.com/ejmr/php-mode/issues/333
+ */
+class Hello
+{
+    /**
+     * @var ThirdClass;
+     */
+    protected $fors;
+
+    /**
+     * @var FourthClassRepository;
+     */
+    protected $psr2s;
+
+    public function __construct(
+        ThirdClass $for,
+        FourthClass $psr2
+    ) {
+    }
+}


### PR DESCRIPTION
Fixed #333 

It seems that font-lock freezes Emacs in certain cases by this pattern `"\\(?:\\s-\\|$\\)"`.

