### PR TITLE
Extract php-send-code function; Pop up *PHP* buffer to easy inspect the result

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -1485,15 +1485,27 @@ a completion list."
   "Send the region between `start' and `end' to PHP for execution.
 The output will appear in the buffer *PHP*."
   (interactive "r")
+  (let ((code (buffer-substring start end))
+		)
+	(php-send-code code)
+	)
+  )
+
+(defun php-send-code (code)
+  "Just send the code and output display in buffer *PHP*"
   (let ((php-buffer (get-buffer-create "*PHP*"))
-        (code (buffer-substring start end)))
+        )
     ;; Calling 'php -r' will fail if we send it code that starts with
     ;; '<?php', which is likely.  So we run the code through this
     ;; function to check for that prefix and remove it.
     (let ((cleaned-php-code (if (string-prefix-p "<?php" code t)
                                 (substring code 5)
                               code)))
-      (call-process php-executable nil php-buffer nil "-r" cleaned-php-code))))
+      (call-process php-executable nil php-buffer nil "-r" cleaned-php-code))
+	(display-buffer-in-side-window php-buffer ()
+								   )
+	)  
+  )
 
 
 (defface php-annotations-annotation-face '((t . (:inherit font-lock-constant-face)))


### PR DESCRIPTION
php-send-region is good to use. But not good enough. I have to find *PHP* buffer after execution. And It's no good for build some easy to extend function. 