### PR TITLE
Fix highlighting of phpdoc type keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ In chronological order:
 68. [David Arroyo Menéndez](https://github.com/davidam)
 69. [USAMI Kenta](https://tadsan.github.io/) (@zonuexe)
 70. [Tim Landscheidt](http://www.tim-landscheidt.de)
+71. [Fabian Wiget](https://github.com/fabacino)
 
 
 [wiki]: https://github.com/ejmr/php-mode/wiki

--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -457,7 +457,19 @@ style from Drupal."
     (should (eq (get-text-property (match-beginning 0) 'face)
                 'font-lock-comment-delimiter-face))
     (should (eq (get-text-property (match-beginning 1) 'face)
-                'font-lock-comment-face))))
+                'font-lock-comment-face))
+
+    (search-forward-regexp "@var \\(int\\) \\(internal linter variable\\) \\*/$")
+    (should (equal (get-text-property (match-beginning 0) 'face) ;; matches `@'
+                   '(php-annotations-annotation-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `i'
+                   '(font-lock-type-face font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-end 1) 'face)       ;; matches ` '
+                   'font-lock-doc-face))
+    (should (equal (get-text-property (match-beginning 2) 'face) ;; matches `i'
+                   'font-lock-doc-face))
+    (should (equal (get-text-property (match-end 2) 'face)       ;; matches ` '
+                   'font-lock-doc-face))))
 
 (ert-deftest php-mode-test-constants ()
   "Proper highlighting for constants."

--- a/php-mode.el
+++ b/php-mode.el
@@ -12,7 +12,7 @@
 (defconst php-mode-version-number "1.18.2"
   "PHP Mode version number.")
 
-(defconst php-mode-modified "2017-02-02"
+(defconst php-mode-modified "2017-02-20"
   "PHP Mode build date.")
 
 ;;; License
@@ -1356,7 +1356,7 @@ a completion list."
               "\\(" (rx (+ (? "\\") (+ (in "0-9A-Z_a-z")) (? "[]") (? "|"))) "\\)+")
      1 font-lock-string-face prepend nil)
     (,(concat "\\(?:|\\|\\s-\\)\\("
-              (regexp-opt php-phpdoc-type-keywords)
+              (regexp-opt php-phpdoc-type-keywords 'words)
               "\\)")
      1 font-lock-type-face prepend nil)
     ("https?://[^\n\t ]+"

--- a/tests/comments.php
+++ b/tests/comments.php
@@ -56,5 +56,8 @@ final class SampleClass
 
         // one-line comment
         // @annotation This is NOT annotation. 4
+
+        /** @var int internal linter variable */
+        $offset = 0;
     }
 }


### PR DESCRIPTION
Words in a phpDoc comment which start with a keyword are not highlighted correctly. Their keyword prefix is highlighted with `font-lock-type-face`, the rest of the string with `font-lock-doc-face`. Expected highlighting would be `font-lock-doc-face` for the whole word.

This PR fixes this bug.

```php
// Before the fix (^ = font-lock-type-face)
/* @var int internal linter variable */
        ^^^ ^^^

// After the fix (^ = font-lock-type-face)
/* @var int internal linter variable */
        ^^^
```