### PR TITLE
Shut up indenting message

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -115,7 +115,7 @@ run with specific customizations set."
      ,(unless custom '(custom-set-variables '(php-lineup-cascaded-calls nil)))
 
      ,(if indent
-          '(indent-region (point-min) (point-max)))
+          '(let ((inhibit-message t)) (indent-region (point-min) (point-max))))
      ,(if magic
           '(should (cl-reduce (lambda (l r) (and l r))
                               (php-mode-test-process-magics))))


### PR DESCRIPTION
It suppresses the output at indentation and clears the test result.

## Before

```
emacs -Q -batch -L . -l php-mode-test.el -f ert-run-tests-batch-and-exit
Running 49 tests (2017-04-02 18:41:29+0900)
   passed   1/49  php-mode-test-arrays
   passed   2/49  php-mode-test-comments
   passed   3/49  php-mode-test-constants
   passed   4/49  php-mode-test-identifiers
Indenting region...
Indenting region... done
   passed   5/49  php-mode-test-issue-115
Indenting region...
Indenting region... done
   passed   6/49  php-mode-test-issue-124
Indenting region...
Indenting region... done
   passed   7/49  php-mode-test-issue-130
Indenting region...
Indenting region... done
...
```

## After

```
emacs -Q -batch -L . -l php-mode-test.el -f ert-run-tests-batch-and-exit
Running 49 tests (2017-04-02 18:44:34+0900)
   passed   1/49  php-mode-test-arrays
   passed   2/49  php-mode-test-comments
   passed   3/49  php-mode-test-constants
   passed   4/49  php-mode-test-identifiers
   passed   5/49  php-mode-test-issue-115
   passed   6/49  php-mode-test-issue-124
   passed   7/49  php-mode-test-issue-130
...
```