### PR TITLE
Fix illegal class name

### DIFF
--- a/tests/annotation.php
+++ b/tests/annotation.php
@@ -14,6 +14,6 @@ class User
 /**
  * @property-read string $myProperty
  */
-class Child extends Parent
+class Child extends Parent_
 {
 }


### PR DESCRIPTION
*(This change does not affect the test.)*

`parent` is not listed in  [List of Keywords](http://php.net/manual/en/reserved.keywords.php), but it is illegal as a class name.

## Before

```
% php -l <(echo '\<?php class Child extends Parent{}')
PHP Fatal error:  Cannot use 'Parent' as class name as it is reserved in /dev/fd/11 on line 1

Fatal error: Cannot use 'Parent' as class name as it is reserved in /dev/fd/11 on line 1

Errors parsing /dev/fd/11
```

## After

```
% php -l <(echo '\<?php class Child extends Parent_{}')
No syntax errors detected in /dev/fd/11
```