### PR TITLE
Add support nullable type annotation

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -471,6 +471,168 @@ style from Drupal."
     (should (equal (get-text-property (match-end 2) 'face)       ;; matches ` '
                    'font-lock-doc-face))))
 
+(ert-deftest php-mode-test-comment-return-type ()
+  "Proper highlighting for type annotation in doc-block."
+  (with-php-mode-test ("doc-comment-return-type.php")
+    ;; Test for premitive type (int)
+    (search-forward-regexp "@return \\(int\\) +\\(A integer value\\)")
+    (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `i'
+                   '(font-lock-type-face font-lock-string-face font-lock-doc-face)))
+    (should (eq (get-text-property (match-beginning 2) 'face) ;; matches `A'
+                'font-lock-doc-face))
+
+    (search-forward-regexp "@return \\(\\?int\\) +\\(A nullable integer value\\)")
+    (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `?'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (1+ (match-beginning 1)) 'face) ;; matches `i'
+                   '(font-lock-type-face font-lock-string-face font-lock-doc-face)))
+    (should (eq (get-text-property (match-beginning 2) 'face) ;; matches `A'
+                'font-lock-doc-face))
+
+    (search-forward-regexp "@return \\(\\int\\[\\]\\) +\\(A list of integer values\\)")
+    (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `i'
+                   '(font-lock-type-face font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (1- (match-end 1)) 'face) ;; matches `]'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (eq (get-text-property (match-beginning 2) 'face) ;; matches `A'
+                'font-lock-doc-face))
+
+    ;; Test for class type (DateTime)
+    (search-forward-regexp "@return \\(DateTime\\) +\\(A DateTime object value\\)")
+    (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `D'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (eq (get-text-property (match-beginning 2) 'face) ;; matches `A'
+                'font-lock-doc-face))
+
+    (search-forward-regexp "@return \\(\\?DateTime\\) +\\(A nullable DateTime object value\\)")
+    (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `?'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (1+ (match-beginning 1)) 'face) ;; matches `D'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (eq (get-text-property (match-beginning 2) 'face) ;; matches `A'
+                'font-lock-doc-face))
+
+    (search-forward-regexp "@return \\(\\DateTime\\[]\\) +\\(A list of DateTime object values\\)")
+    (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `D'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (1- (match-end 1)) 'face) ;; matches `]'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (eq (get-text-property (match-beginning 2) 'face) ;; matches `A'
+                'font-lock-doc-face))
+
+    ;; Test for class type (stdClass)
+    (search-forward-regexp "@return \\(stdClass\\) +\\(A stdClass object value\\)")
+    (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `s'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (eq (get-text-property (match-beginning 2) 'face) ;; matches `A'
+                'font-lock-doc-face))
+
+    (search-forward-regexp "@return \\(\\?stdClass\\) +\\(A nullable stdClass object value\\)")
+    (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `?'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (1+ (match-beginning 1)) 'face) ;; matches `s'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (eq (get-text-property (match-beginning 2) 'face) ;; matches `A'
+                'font-lock-doc-face))
+
+    (search-forward-regexp "@return \\(stdClass\\[]\\) +\\(A list of stdClass object values\\)")
+    (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `s'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (1- (match-end 1)) 'face) ;; matches `]'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (eq (get-text-property (match-beginning 2) 'face) ;; matches `A'
+                'font-lock-doc-face))
+
+    ;; Test for class type (\App\User)
+    (search-forward-regexp "@return \\(\\\\App\\\\User\\) +\\(A \\\\App\\\\User object value\\)")
+    (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `\'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (1+ (match-beginning 1)) 'face) ;; matches `A'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (eq (get-text-property (match-beginning 2) 'face) ;; matches `A'
+                'font-lock-doc-face))
+
+    (search-forward-regexp "@return \\(\\?\\\\App\\\\User\\) +\\(A nullable \\\\App\\\\User object value\\)")
+    (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `?'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (1+ (match-beginning 1)) 'face) ;; matches `\\'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (eq (get-text-property (match-beginning 2) 'face) ;; matches `A'
+                'font-lock-doc-face))
+
+    (search-forward-regexp "@return \\(\\\\App\\\\User\\[]\\) +\\(A list of \\\\App\\\\User object values\\)")
+    (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `\'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (1- (match-end 1)) 'face) ;; matches `]'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (eq (get-text-property (match-beginning 2) 'face) ;; matches `A'
+                'font-lock-doc-face))
+
+    ;; Test for multiple types
+    (search-forward-regexp "@return \\(int\\)\\(|\\)\\(string\\) +\\(Multiple types by int and string\\)")
+    (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `i'
+                   '(font-lock-type-face font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-beginning 2) 'face) ;; matches `|'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-beginning 3) 'face) ;; matches `s'
+                   '(font-lock-type-face font-lock-string-face font-lock-doc-face)))
+    (should (eq (get-text-property (match-beginning 4) 'face) ;; matches `M'
+                'font-lock-doc-face))
+
+    (search-forward-regexp "@return \\(int\\[]\\)\\(|\\)\\(string\\) +\\(Multiple types by list of int and string\\)")
+    (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `i'
+                   '(font-lock-type-face font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (1- (match-end 1)) 'face) ;; matches `]'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-beginning 2) 'face) ;; matches `|'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-beginning 3) 'face) ;; matches `s'
+                   '(font-lock-type-face font-lock-string-face font-lock-doc-face)))
+    (should (eq (get-text-property (match-beginning 4) 'face) ;; matches `M'
+                'font-lock-doc-face))
+
+    (search-forward-regexp "@return \\(int\\)\\(|\\)\\(stdClass\\) +\\(Multiple types by int and stdClass\\)")
+    (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `i'
+                   '(font-lock-type-face font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-beginning 2) 'face) ;; matches `|'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-beginning 3) 'face) ;; matches `s'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (eq (get-text-property (match-beginning 4) 'face) ;; matches `M'
+                'font-lock-doc-face))
+
+    (search-forward-regexp "@return \\(int\\)\\(|\\)\\(\\\\App\\\\User\\) +\\(Multiple types by int and \\\\App\\\\User\\)")
+    (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `i'
+                   '(font-lock-type-face font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-beginning 2) 'face) ;; matches `|'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-beginning 3) 'face) ;; matches `\'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (eq (get-text-property (match-beginning 4) 'face) ;; matches `M'
+                'font-lock-doc-face))
+
+    (search-forward-regexp "@return \\(DateTime\\)\\(|\\)\\(int\\) +\\(Multiple types by DateTime and int\\)")
+    (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `D'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-beginning 2) 'face) ;; matches `|'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-beginning 3) 'face) ;; matches `i'
+                   '(font-lock-type-face font-lock-string-face font-lock-doc-face)))
+    (should (eq (get-text-property (match-beginning 4) 'face) ;; matches `M'
+                'font-lock-doc-face))
+
+    (search-forward-regexp "@return \\(\\\\App\\\\User\\)\\(|\\)\\(int\\) +\\(Multiple types by \\\\App\\\\User and int\\)")
+    (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `\'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (1+ (match-beginning 1)) 'face) ;; matches `A'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-beginning 2) 'face) ;; matches `|'
+                   '(font-lock-string-face font-lock-doc-face)))
+    (should (equal (get-text-property (match-beginning 3) 'face) ;; matches `i'
+                   '(font-lock-type-face font-lock-string-face font-lock-doc-face)))
+    (should (eq (get-text-property (match-beginning 4) 'face) ;; matches `M'
+                'font-lock-doc-face))))
+
 (ert-deftest php-mode-test-constants ()
   "Proper highlighting for constants."
   (custom-set-variables '(php-extra-constants (quote ("extraconstant"))))

--- a/php-mode.el
+++ b/php-mode.el
@@ -1374,9 +1374,9 @@ a completion list."
     (,(rx "$" (in "A-Za-z_") (* (in "0-9A-Za-z_")))
      0 font-lock-variable-name-face prepend nil)
     (,(concat "\\s-@" (regexp-opt php-phpdoc-type-tags) "\\s-+"
-              "\\(" (rx (+ (? "\\") (+ (in "0-9A-Z_a-z")) (? "[]") (? "|"))) "\\)+")
+              "\\(" (rx (+ (? "?") (? "\\") (+ (in "0-9A-Z_a-z")) (? "[]") (? "|"))) "\\)+")
      1 font-lock-string-face prepend nil)
-    (,(concat "\\(?:|\\|\\s-\\)\\("
+    (,(concat "\\(?:|\\|\\?\\|\\s-\\)\\("
               (regexp-opt php-phpdoc-type-keywords 'words)
               "\\)")
      1 font-lock-type-face prepend nil)

--- a/tests/doc-comment-return-type.php
+++ b/tests/doc-comment-return-type.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Test for type annotation in doc comment
+ *
+ * The specification is defined in PSR-5 (draft) Appendix A. Types.
+ * This implementation contains unstandardized specification.
+ *
+ * @see https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc.md#appendix-a-types
+ */
+
+// Test for premitive type (int)
+
+/** @return int   A integer value */
+/** @return ?int  A nullable integer value */
+/** @return int[] A list of integer values */
+
+
+// Test for class type (DateTime)
+
+/** @return DateTime   A DateTime object value */
+/** @return ?DateTime  A nullable DateTime object value */
+/** @return DateTime[] A list of DateTime object values */
+
+
+// Test for class type (stdClass)
+
+/** @return stdClass   A stdClass object value */
+/** @return ?stdClass  A nullable stdClass object value */
+/** @return stdClass[] A list of stdClass object values */
+
+// Test for class type (\App\User)
+
+/** @return \App\User   A \App\User object value */
+/** @return ?\App\User  A nullable \App\User object value */
+/** @return \App\User[] A list of \App\User object values */
+
+// Test for multiple types
+
+/** @return int|string    Multiple types by int and string */
+/** @return int[]|string  Multiple types by list of int and string */
+/** @return int|stdClass    Multiple types by int and stdClass */
+/** @return int|\App\User    Multiple types by int and \App\User */
+/** @return DateTime|int    Multiple types by DateTime and int */
+/** @return \App\User|int    Multiple types by \App\User and int */


### PR DESCRIPTION
This implementation contains unstandardized specification.
But, this form is derived from the [type declarations](http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration).

## Before

<img width="547" alt="2017-04-02 9 18 32" src="https://cloud.githubusercontent.com/assets/822086/24587070/4d3c3b64-17ea-11e7-897f-29acb7e54799.png">

## After

<img width="548" alt="2017-04-02 9 19 29" src="https://cloud.githubusercontent.com/assets/822086/24587069/4d3c3970-17ea-11e7-9708-dabbf580e214.png">
