### PR TITLE
Add defgroup :tag and fix comment style

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -997,9 +997,12 @@ PHP heredoc."
   (cons "PHP" (c-lang-const c-mode-menu php)))
 
 
-;;; Faces
+;; Faces
+
+;;;###autoload
 (defgroup php-faces nil
   "Faces used in PHP Mode"
+  :tag "PHP Faces"
   :group 'php
   :group 'faces)
 
@@ -1428,7 +1431,7 @@ a completion list."
                 (format "%smanual/%s/" php-site-url php-manual-url))))
 
 
-;;; Font Lock
+;; Font Lock
 (defconst php-phpdoc-type-keywords
   (list "string" "integer" "int" "boolean" "bool" "float"
         "double" "object" "mixed" "array" "resource" "$this"

--- a/php-mode.el
+++ b/php-mode.el
@@ -356,22 +356,6 @@ This variable can take one of the following symbol values:
   :set 'php-mode-custom-coding-style-set
   :initialize 'custom-initialize-default)
 
-(defcustom php-search-documentation-browser-function nil
-  "Function to display PHP documentation in a WWW browser.
-
-If non-nil, this shadows the value of `browse-url-browser-function' when
-calling `php-search-documentation' or `php-search-local-documentation'."
-  :type '(choice (const :tag "default" nil) function)
-  :link '(variable-link browse-url-browser-function))
-
-(defcustom php-class-suffix-when-insert "::"
-  "Suffix for inserted class."
-  :type 'string)
-
-(defcustom php-namespace-suffix-when-insert "\\"
-  "Suffix for inserted namespace."
-  :type 'string)
-
 (defun php-mode-custom-coding-style-set (sym value)
   (when (eq major-mode 'php-mode)
     (set         sym value)
@@ -1325,7 +1309,14 @@ current `tags-file-name'."
         (message "Arglist for %s: %s" tagname arglist)
         (message "Unknown function: %s" tagname))))
 
-;; Functions for documentation
+(defcustom php-search-documentation-browser-function nil
+  "Function to display PHP documentation in a WWW browser.
+
+If non-nil, this shadows the value of `browse-url-browser-function' when
+calling `php-search-documentation' or `php-search-local-documentation'."
+  :type '(choice (const :tag "default" nil) function)
+  :link '(variable-link browse-url-browser-function))
+
 (defun php-browse-documentation-url (url)
   "Browse a documentation URL using the configured browser function.
 
@@ -1649,6 +1640,14 @@ The output will appear in the buffer *PHP*."
     ad-do-it
     (modify-syntax-entry ?\\ old-syntax)))
 
+
+(defcustom php-class-suffix-when-insert "::"
+  "Suffix for inserted class."
+  :type 'string)
+
+(defcustom php-namespace-suffix-when-insert "\\"
+  "Suffix for inserted namespace."
+  :type 'string)
 
 (defvar php--re-namespace-pattern
   (php-create-regexp-for-classlike "namespace"))

--- a/php-mode.el
+++ b/php-mode.el
@@ -356,6 +356,22 @@ This variable can take one of the following symbol values:
   :set 'php-mode-custom-coding-style-set
   :initialize 'custom-initialize-default)
 
+(defcustom php-search-documentation-browser-function nil
+  "Function to display PHP documentation in a WWW browser.
+
+If non-nil, this shadows the value of `browse-url-browser-function' when
+calling `php-search-documentation' or `php-search-local-documentation'."
+  :type '(choice (const :tag "default" nil) function)
+  :link '(variable-link browse-url-browser-function))
+
+(defcustom php-class-suffix-when-insert "::"
+  "Suffix for inserted class."
+  :type 'string)
+
+(defcustom php-namespace-suffix-when-insert "\\"
+  "Suffix for inserted namespace."
+  :type 'string)
+
 (defun php-mode-custom-coding-style-set (sym value)
   (when (eq major-mode 'php-mode)
     (set         sym value)
@@ -1309,14 +1325,7 @@ current `tags-file-name'."
         (message "Arglist for %s: %s" tagname arglist)
         (message "Unknown function: %s" tagname))))
 
-(defcustom php-search-documentation-browser-function nil
-  "Function to display PHP documentation in a WWW browser.
-
-If non-nil, this shadows the value of `browse-url-browser-function' when
-calling `php-search-documentation' or `php-search-local-documentation'."
-  :type '(choice (const :tag "default" nil) function)
-  :link '(variable-link browse-url-browser-function))
-
+;; Functions for documentation
 (defun php-browse-documentation-url (url)
   "Browse a documentation URL using the configured browser function.
 
@@ -1640,14 +1649,6 @@ The output will appear in the buffer *PHP*."
     ad-do-it
     (modify-syntax-entry ?\\ old-syntax)))
 
-
-(defcustom php-class-suffix-when-insert "::"
-  "Suffix for inserted class."
-  :type 'string)
-
-(defcustom php-namespace-suffix-when-insert "\\"
-  "Suffix for inserted namespace."
-  :type 'string)
 
 (defvar php--re-namespace-pattern
   (php-create-regexp-for-classlike "namespace"))

--- a/php-mode.el
+++ b/php-mode.el
@@ -1314,6 +1314,7 @@ current `tags-file-name'."
 
 If non-nil, this shadows the value of `browse-url-browser-function' when
 calling `php-search-documentation' or `php-search-local-documentation'."
+  :group 'php
   :type '(choice (const :tag "default" nil) function)
   :link '(variable-link browse-url-browser-function))
 
@@ -1643,10 +1644,12 @@ The output will appear in the buffer *PHP*."
 
 (defcustom php-class-suffix-when-insert "::"
   "Suffix for inserted class."
+  :group 'php
   :type 'string)
 
 (defcustom php-namespace-suffix-when-insert "\\"
   "Suffix for inserted namespace."
+  :group 'php
   :type 'string)
 
 (defvar php--re-namespace-pattern


### PR DESCRIPTION
This change is for trivial aesthetic.

## Before

<img width="483" alt="2017-04-04 23 05 11" src="https://cloud.githubusercontent.com/assets/822086/24660711/34d7672c-198b-11e7-981a-cfe92d7b377c.png">

<img width="378" alt="2017-04-04 23 06 07" src="https://cloud.githubusercontent.com/assets/822086/24660756/5562eb60-198b-11e7-90f8-9ed0f49c2b12.png">


## After

<img width="482" alt="2017-04-04 22 57 05" src="https://cloud.githubusercontent.com/assets/822086/24660710/34d6cd58-198b-11e7-9820-85a4955e427e.png">
