### PR TITLE
Add faces for syntax elements #2

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -631,7 +631,24 @@ style from Drupal."
     (should (equal (get-text-property (match-beginning 3) 'face) ;; matches `i'
                    '(font-lock-type-face php-string font-lock-doc-face)))
     (should (eq (get-text-property (match-beginning 4) 'face) ;; matches `M'
-                'font-lock-doc-face))))
+                'font-lock-doc-face))
+
+    (search-forward-regexp "@return \\(\\$this\\) +\\(this is special variable\\)")
+    (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `$'
+                   '(php-doc-$this-sigil php-doc-variable-sigil font-lock-doc-face)))
+    (should (equal (get-text-property (1+ (match-beginning 1)) 'face) ;; matches `t'
+                   '(php-doc-$this php-variable-name font-lock-doc-face)))
+    (should (eq (get-text-property (match-beginning 2) 'face) ;; matches `M'
+                'font-lock-doc-face))
+
+    (search-forward-regexp "@return \\(\\$that\\) +\\(that is NOT special variable\\)")
+    (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `$'
+                   '(php-doc-variable-sigil font-lock-doc-face)))
+    (should (equal (get-text-property (1+ (match-beginning 1)) 'face) ;; matches `t'
+                   '(php-variable-name font-lock-doc-face)))
+    (should (eq (get-text-property (match-beginning 2) 'face) ;; matches `M'
+                'font-lock-doc-face))
+    ))
 
 (ert-deftest php-mode-test-constants ()
   "Proper highlighting for constants."
@@ -697,18 +714,21 @@ style from Drupal."
   (with-php-mode-test ("variables.php")
     (let ((variables '("regularVariable"
                        "variableVariable"
-                       "staticVariable"
-                       "memberVariable")))
+                       "staticVariable")))
       (dolist (variable variables)
         (save-excursion
           (search-forward variable)
           (goto-char (match-beginning 0))
           (should (eq 'php-variable-name
                       (get-text-property (point) 'face))))))
+
+    (search-forward "memberVariable")
+    (should (eq 'php-property-name
+                (get-text-property (match-beginning 0) 'face)))
+
     (search-forward "funCall")
-    (goto-char (match-beginning 0))
-    (should-not (eq 'php-variable-name
-                    (get-text-property (point) 'face)))))
+    (should-not (eq 'php-property-name
+                    (get-text-property (match-beginning 0) 'face)))))
 
 (ert-deftest php-mode-test-arrays()
   "Proper highlighting for array keyword."
@@ -799,9 +819,9 @@ style from Drupal."
   (with-php-mode-test ("issue-201.php")
     (search-forward "Start:")
     (search-forward "$this")
-    (should (eq 'php-constant (get-text-property (- (point) 1) 'face)))
+    (should (eq 'php-$this (get-text-property (- (point) 1) 'face)))
     (search-forward "$that")
-    (should (eq 'php-constant (get-text-property (- (point) 1) 'face)))
+    (should (eq 'php-$this (get-text-property (- (point) 1) 'face)))
     (search-forward "self")
     (should (eq 'php-keyword (get-text-property (- (point) 1) 'face)))
     (search-forward "static")
@@ -870,10 +890,12 @@ style from Drupal."
     (should (eq 'php-variable-name (get-text-property (1- (point)) 'face)))
 
     (search-forward "$this")
-    (should (eq 'php-constant (get-text-property (1- (point)) 'face)))
+    (should (eq 'php-$this-sigil (get-text-property (match-beginning 0) 'face)))
+    (should (eq 'php-$this (get-text-property (1+ (match-beginning 0)) 'face)))
 
     (search-forward "$x")
-    (should (eq 'php-variable-name (get-text-property (1- (point)) 'face)))))
+    (should (eq 'php-variable-sigil (get-text-property (match-beginning 0) 'face)))
+    (should (eq 'php-variable-name (get-text-property (1+ (match-beginning 0)) 'face)))))
 
 (ert-deftest psr-5-style-tag-annotation ()
   "PSR-5 style tag annotation."

--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -133,7 +133,7 @@ run with specific customizations set."
     (search-forward "@ORM")
     (should (equal
              (get-text-property (match-beginning 0) 'face)
-             '(php-doc-annotation-tag-face font-lock-doc-face)))))
+             '(php-doc-annotation-tag font-lock-doc-face)))))
 
 (ert-deftest php-mode-test-issue-9 ()
   "Single quote in text in HTML misinterpreted.
@@ -145,7 +145,7 @@ have a string face."
                       (forward-char) ;; Jump to after the opening apostrophe
     (should-not (eq
                  (get-text-property (point) 'face)
-                 'php-string-face))))
+                 'php-string))))
 
 (ert-deftest php-mode-test-issue-14 ()
   "Array indentation."
@@ -189,7 +189,7 @@ Gets the face of the text after the comma."
     (search-forward "= ")
     (while (not (looking-at ";"))
       (should (eq (get-text-property (point) 'face)
-                  'php-string-face))
+                  'php-string))
       (forward-char))))
 
 (ert-deftest php-mode-test-issue-22 ()
@@ -330,7 +330,7 @@ style from Drupal."
       (dolist (variable variables)
         (search-forward variable)
         (goto-char (match-beginning 0))
-        (should (eq 'php-variable-name-face
+        (should (eq 'php-variable-name
                     (get-text-property (point) 'face)))))))
 
 (ert-deftest php-mode-test-issue-144 ()
@@ -352,7 +352,7 @@ style from Drupal."
 
     (search-forward "@copyright")
     (should (equal (get-text-property (match-beginning 0) 'face)
-                   '(php-doc-annotation-tag-face font-lock-doc-face)))
+                   '(php-doc-annotation-tag font-lock-doc-face)))
     (search-forward-regexp "@link +\\(https://github.com/ejmr/php-mode\\)")
     (should (equal (get-text-property (match-beginning 1) 'face)
                    '(link font-lock-doc-face)))
@@ -389,33 +389,33 @@ style from Drupal."
     ;; Class level doc-comment
     (search-forward-regexp "{@internal \\(Description\\)}")
     (should (equal (get-text-property (match-beginning 0) 'face)
-                   '(php-doc-annotation-tag-face font-lock-doc-face)))
+                   '(php-doc-annotation-tag font-lock-doc-face)))
     (should (equal (get-text-property (match-beginning 1) 'face)
-                   '(php-string-face php-doc-annotation-tag-face font-lock-doc-face)))
+                   '(php-string php-doc-annotation-tag font-lock-doc-face)))
 
     (should (equal (get-text-property (1- (match-end 0)) 'face)
-                   '(php-doc-annotation-tag-face font-lock-doc-face)))
+                   '(php-doc-annotation-tag font-lock-doc-face)))
     (should (equal (get-text-property (match-end 0) 'face)
                    'font-lock-doc-face))
 
     (search-forward-regexp "@property\\(-read\\)")
     (should (equal (get-text-property (match-beginning 0) 'face)
-                   '(php-doc-annotation-tag-face font-lock-doc-face)))
+                   '(php-doc-annotation-tag font-lock-doc-face)))
 
     (should (equal (get-text-property (match-beginning 1) 'face)
-                   '(php-doc-annotation-tag-face font-lock-doc-face)))
+                   '(php-doc-annotation-tag font-lock-doc-face)))
 
     (search-forward-regexp "@ORM\\(\\\\Table\\)")
     (should (equal (get-text-property (match-beginning 0) 'face)
-                   '(php-doc-annotation-tag-face font-lock-doc-face)))
+                   '(php-doc-annotation-tag font-lock-doc-face)))
     (should (equal (get-text-property (match-beginning 1) 'face)
-                   '(php-doc-annotation-tag-face font-lock-doc-face)))
+                   '(php-doc-annotation-tag font-lock-doc-face)))
 
     (search-forward-regexp "@var \\(string\\) \\(sample property doc-comment\\)")
     (should (equal (get-text-property (match-beginning 0) 'face)
-                   '(php-doc-annotation-tag-face font-lock-doc-face)))
+                   '(php-doc-annotation-tag font-lock-doc-face)))
     (should (equal (get-text-property (match-beginning 1) 'face)
-                   '(font-lock-type-face php-string-face font-lock-doc-face)))
+                   '(font-lock-type-face php-string font-lock-doc-face)))
     (should (equal (get-text-property (match-beginning 2) 'face)
                    'font-lock-doc-face))
 
@@ -427,23 +427,23 @@ style from Drupal."
 
     (search-forward-regexp "@var \\(string\\)|\\(bool\\)|\\(array\\)\\([[]]\\)|\\(ArrayObject\\) \\*/$")
     (should (equal (get-text-property (match-beginning 0) 'face) ;; matches `@'
-                   '(php-doc-annotation-tag-face font-lock-doc-face)))
+                   '(php-doc-annotation-tag font-lock-doc-face)))
     (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `s'
-                   '(font-lock-type-face php-string-face font-lock-doc-face)))
+                   '(font-lock-type-face php-string font-lock-doc-face)))
     (should (equal (get-text-property (match-end 1) 'face)       ;; matches `|'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (equal (get-text-property (match-beginning 2) 'face) ;; matches `b'
-                   '(font-lock-type-face php-string-face font-lock-doc-face)))
+                   '(font-lock-type-face php-string font-lock-doc-face)))
     (should (equal (get-text-property (match-end 2) 'face)       ;; matches `|'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (equal (get-text-property (match-beginning 3) 'face) ;; matches `a'
-                   '(font-lock-type-face php-string-face font-lock-doc-face)))
+                   '(font-lock-type-face php-string font-lock-doc-face)))
     (should (equal (get-text-property (match-beginning 4) 'face) ;; matches `['
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (equal (get-text-property (match-end 4) 'face)       ;; matches `|'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (equal (get-text-property (match-beginning 5) 'face) ;; matches `A'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (equal (get-text-property (match-end 5) 'face)       ;; matches ` '
                    ' font-lock-doc-face))
 
@@ -461,9 +461,9 @@ style from Drupal."
 
     (search-forward-regexp "@var \\(int\\) \\(internal linter variable\\) \\*/$")
     (should (equal (get-text-property (match-beginning 0) 'face) ;; matches `@'
-                   '(php-doc-annotation-tag-face font-lock-doc-face)))
+                   '(php-doc-annotation-tag font-lock-doc-face)))
     (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `i'
-                   '(font-lock-type-face php-string-face font-lock-doc-face)))
+                   '(font-lock-type-face php-string font-lock-doc-face)))
     (should (equal (get-text-property (match-end 1) 'face)       ;; matches ` '
                    'font-lock-doc-face))
     (should (equal (get-text-property (match-beginning 2) 'face) ;; matches `i'
@@ -477,159 +477,159 @@ style from Drupal."
     ;; Test for premitive type (int)
     (search-forward-regexp "@return \\(int\\) +\\(A integer value\\)")
     (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `i'
-                   '(font-lock-type-face php-string-face font-lock-doc-face)))
+                   '(font-lock-type-face php-string font-lock-doc-face)))
     (should (eq (get-text-property (match-beginning 2) 'face) ;; matches `A'
                 'font-lock-doc-face))
 
     (search-forward-regexp "@return \\(\\?int\\) +\\(A nullable integer value\\)")
     (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `?'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (equal (get-text-property (1+ (match-beginning 1)) 'face) ;; matches `i'
-                   '(font-lock-type-face php-string-face font-lock-doc-face)))
+                   '(font-lock-type-face php-string font-lock-doc-face)))
     (should (eq (get-text-property (match-beginning 2) 'face) ;; matches `A'
                 'font-lock-doc-face))
 
     (search-forward-regexp "@return \\(\\int\\[\\]\\) +\\(A list of integer values\\)")
     (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `i'
-                   '(font-lock-type-face php-string-face font-lock-doc-face)))
+                   '(font-lock-type-face php-string font-lock-doc-face)))
     (should (equal (get-text-property (1- (match-end 1)) 'face) ;; matches `]'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (eq (get-text-property (match-beginning 2) 'face) ;; matches `A'
                 'font-lock-doc-face))
 
     ;; Test for class type (DateTime)
     (search-forward-regexp "@return \\(DateTime\\) +\\(A DateTime object value\\)")
     (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `D'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (eq (get-text-property (match-beginning 2) 'face) ;; matches `A'
                 'font-lock-doc-face))
 
     (search-forward-regexp "@return \\(\\?DateTime\\) +\\(A nullable DateTime object value\\)")
     (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `?'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (equal (get-text-property (1+ (match-beginning 1)) 'face) ;; matches `D'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (eq (get-text-property (match-beginning 2) 'face) ;; matches `A'
                 'font-lock-doc-face))
 
     (search-forward-regexp "@return \\(\\DateTime\\[]\\) +\\(A list of DateTime object values\\)")
     (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `D'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (equal (get-text-property (1- (match-end 1)) 'face) ;; matches `]'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (eq (get-text-property (match-beginning 2) 'face) ;; matches `A'
                 'font-lock-doc-face))
 
     ;; Test for class type (stdClass)
     (search-forward-regexp "@return \\(stdClass\\) +\\(A stdClass object value\\)")
     (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `s'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (eq (get-text-property (match-beginning 2) 'face) ;; matches `A'
                 'font-lock-doc-face))
 
     (search-forward-regexp "@return \\(\\?stdClass\\) +\\(A nullable stdClass object value\\)")
     (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `?'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (equal (get-text-property (1+ (match-beginning 1)) 'face) ;; matches `s'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (eq (get-text-property (match-beginning 2) 'face) ;; matches `A'
                 'font-lock-doc-face))
 
     (search-forward-regexp "@return \\(stdClass\\[]\\) +\\(A list of stdClass object values\\)")
     (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `s'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (equal (get-text-property (1- (match-end 1)) 'face) ;; matches `]'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (eq (get-text-property (match-beginning 2) 'face) ;; matches `A'
                 'font-lock-doc-face))
 
     ;; Test for class type (\App\User)
     (search-forward-regexp "@return \\(\\\\App\\\\User\\) +\\(A \\\\App\\\\User object value\\)")
     (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `\'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (equal (get-text-property (1+ (match-beginning 1)) 'face) ;; matches `A'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (eq (get-text-property (match-beginning 2) 'face) ;; matches `A'
                 'font-lock-doc-face))
 
     (search-forward-regexp "@return \\(\\?\\\\App\\\\User\\) +\\(A nullable \\\\App\\\\User object value\\)")
     (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `?'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (equal (get-text-property (1+ (match-beginning 1)) 'face) ;; matches `\\'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (eq (get-text-property (match-beginning 2) 'face) ;; matches `A'
                 'font-lock-doc-face))
 
     (search-forward-regexp "@return \\(\\\\App\\\\User\\[]\\) +\\(A list of \\\\App\\\\User object values\\)")
     (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `\'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (equal (get-text-property (1- (match-end 1)) 'face) ;; matches `]'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (eq (get-text-property (match-beginning 2) 'face) ;; matches `A'
                 'font-lock-doc-face))
 
     ;; Test for multiple types
     (search-forward-regexp "@return \\(int\\)\\(|\\)\\(string\\) +\\(Multiple types by int and string\\)")
     (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `i'
-                   '(font-lock-type-face php-string-face font-lock-doc-face)))
+                   '(font-lock-type-face php-string font-lock-doc-face)))
     (should (equal (get-text-property (match-beginning 2) 'face) ;; matches `|'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (equal (get-text-property (match-beginning 3) 'face) ;; matches `s'
-                   '(font-lock-type-face php-string-face font-lock-doc-face)))
+                   '(font-lock-type-face php-string font-lock-doc-face)))
     (should (eq (get-text-property (match-beginning 4) 'face) ;; matches `M'
                 'font-lock-doc-face))
 
     (search-forward-regexp "@return \\(int\\[]\\)\\(|\\)\\(string\\) +\\(Multiple types by list of int and string\\)")
     (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `i'
-                   '(font-lock-type-face php-string-face font-lock-doc-face)))
+                   '(font-lock-type-face php-string font-lock-doc-face)))
     (should (equal (get-text-property (1- (match-end 1)) 'face) ;; matches `]'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (equal (get-text-property (match-beginning 2) 'face) ;; matches `|'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (equal (get-text-property (match-beginning 3) 'face) ;; matches `s'
-                   '(font-lock-type-face php-string-face font-lock-doc-face)))
+                   '(font-lock-type-face php-string font-lock-doc-face)))
     (should (eq (get-text-property (match-beginning 4) 'face) ;; matches `M'
                 'font-lock-doc-face))
 
     (search-forward-regexp "@return \\(int\\)\\(|\\)\\(stdClass\\) +\\(Multiple types by int and stdClass\\)")
     (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `i'
-                   '(font-lock-type-face php-string-face font-lock-doc-face)))
+                   '(font-lock-type-face php-string font-lock-doc-face)))
     (should (equal (get-text-property (match-beginning 2) 'face) ;; matches `|'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (equal (get-text-property (match-beginning 3) 'face) ;; matches `s'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (eq (get-text-property (match-beginning 4) 'face) ;; matches `M'
                 'font-lock-doc-face))
 
     (search-forward-regexp "@return \\(int\\)\\(|\\)\\(\\\\App\\\\User\\) +\\(Multiple types by int and \\\\App\\\\User\\)")
     (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `i'
-                   '(font-lock-type-face php-string-face font-lock-doc-face)))
+                   '(font-lock-type-face php-string font-lock-doc-face)))
     (should (equal (get-text-property (match-beginning 2) 'face) ;; matches `|'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (equal (get-text-property (match-beginning 3) 'face) ;; matches `\'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (eq (get-text-property (match-beginning 4) 'face) ;; matches `M'
                 'font-lock-doc-face))
 
     (search-forward-regexp "@return \\(DateTime\\)\\(|\\)\\(int\\) +\\(Multiple types by DateTime and int\\)")
     (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `D'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (equal (get-text-property (match-beginning 2) 'face) ;; matches `|'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (equal (get-text-property (match-beginning 3) 'face) ;; matches `i'
-                   '(font-lock-type-face php-string-face font-lock-doc-face)))
+                   '(font-lock-type-face php-string font-lock-doc-face)))
     (should (eq (get-text-property (match-beginning 4) 'face) ;; matches `M'
                 'font-lock-doc-face))
 
     (search-forward-regexp "@return \\(\\\\App\\\\User\\)\\(|\\)\\(int\\) +\\(Multiple types by \\\\App\\\\User and int\\)")
     (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `\'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (equal (get-text-property (1+ (match-beginning 1)) 'face) ;; matches `A'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (equal (get-text-property (match-beginning 2) 'face) ;; matches `|'
-                   '(php-string-face font-lock-doc-face)))
+                   '(php-string font-lock-doc-face)))
     (should (equal (get-text-property (match-beginning 3) 'face) ;; matches `i'
-                   '(font-lock-type-face php-string-face font-lock-doc-face)))
+                   '(font-lock-type-face php-string font-lock-doc-face)))
     (should (eq (get-text-property (match-beginning 4) 'face) ;; matches `M'
                 'font-lock-doc-face))))
 
@@ -650,7 +650,7 @@ style from Drupal."
       (dolist (variable variables)
         (search-forward variable)
         (goto-char (match-beginning 0))
-        (should (eq 'php-constant-face
+        (should (eq 'php-constant
                     (get-text-property (point) 'face))))))
   (custom-set-variables '(php-extra-constants (quote ())))
   (with-php-mode-test ("constants.php")
@@ -661,7 +661,7 @@ style from Drupal."
       (dolist (variable variables)
         (search-forward variable)
         (goto-char (match-beginning 0))
-        (should (not (eq 'php-constant-face
+        (should (not (eq 'php-constant
                      (get-text-property (point) 'face))))))))
 
 (ert-deftest php-mode-test-identifiers()
@@ -677,19 +677,19 @@ style from Drupal."
                     (get-text-property (point) 'face)))))
     (search-forward "var")
     (goto-char (match-beginning 0))
-    (should (eq 'php-variable-name-face
+    (should (eq 'php-variable-name
                 (get-text-property (point) 'face)))
     (search-forward "syntaxerror")
     (goto-char (match-beginning 0))
-    (should (not (eq 'php-variable-name-face
+    (should (not (eq 'php-variable-name
                      (get-text-property (point) 'face))))
     (search-forward "ClassName")
     (goto-char (match-beginning 0))
-    (should (eq 'php-constant-face
+    (should (eq 'php-constant
                 (get-text-property (point) 'face)))
     (search-forward "SpaceName")
     (goto-char (match-beginning 0))
-    (should (eq 'php-constant-face
+    (should (eq 'php-constant
                 (get-text-property (point) 'face)))))
 
 (ert-deftest php-mode-test-variables()
@@ -703,11 +703,11 @@ style from Drupal."
         (save-excursion
           (search-forward variable)
           (goto-char (match-beginning 0))
-          (should (eq 'php-variable-name-face
+          (should (eq 'php-variable-name
                       (get-text-property (point) 'face))))))
     (search-forward "funCall")
     (goto-char (match-beginning 0))
-    (should-not (eq 'php-variable-name-face
+    (should-not (eq 'php-variable-name
                     (get-text-property (point) 'face)))))
 
 (ert-deftest php-mode-test-arrays()
@@ -732,7 +732,7 @@ style from Drupal."
   "Test escaped quotes in string literals"
   (with-php-mode-test ("issue-174.php")
     (while (search-forward "quotation mark" nil t)
-      (should (eq 'php-string-face
+      (should (eq 'php-string
                   (get-text-property (- (point) 1) 'face))))))
 
 (ert-deftest php-mode-test-issue-175 ()
@@ -768,7 +768,7 @@ style from Drupal."
     (search-forward "$values as")
     (should (eq 'php-keyword
                 (get-text-property (- (point) 1) 'face)))
-    (should (eq 'php-variable-name-face
+    (should (eq 'php-variable-name
                 (get-text-property (+ (point) 2) 'face)))
     (search-forward "test as")
     (should (eq 'php-keyword
@@ -799,9 +799,9 @@ style from Drupal."
   (with-php-mode-test ("issue-201.php")
     (search-forward "Start:")
     (search-forward "$this")
-    (should (eq 'php-constant-face (get-text-property (- (point) 1) 'face)))
+    (should (eq 'php-constant (get-text-property (- (point) 1) 'face)))
     (search-forward "$that")
-    (should (eq 'php-constant-face (get-text-property (- (point) 1) 'face)))
+    (should (eq 'php-constant (get-text-property (- (point) 1) 'face)))
     (search-forward "self")
     (should (eq 'php-keyword (get-text-property (- (point) 1) 'face)))
     (search-forward "static")
@@ -867,13 +867,13 @@ style from Drupal."
   "Test highlight after string literal which contains many escaped quotes."
   (with-php-mode-test ("issue-253.php")
     (search-forward "$x" nil nil 3)
-    (should (eq 'php-variable-name-face (get-text-property (1- (point)) 'face)))
+    (should (eq 'php-variable-name (get-text-property (1- (point)) 'face)))
 
     (search-forward "$this")
-    (should (eq 'php-constant-face (get-text-property (1- (point)) 'face)))
+    (should (eq 'php-constant (get-text-property (1- (point)) 'face)))
 
     (search-forward "$x")
-    (should (eq 'php-variable-name-face (get-text-property (1- (point)) 'face)))))
+    (should (eq 'php-variable-name (get-text-property (1- (point)) 'face)))))
 
 (ert-deftest psr-5-style-tag-annotation ()
   "PSR-5 style tag annotation."
@@ -883,24 +883,24 @@ style from Drupal."
              do
              (progn
                (should (equal (get-text-property (match-beginning i) 'face)
-                              '(php-doc-annotation-tag-face font-lock-doc-face)))
+                              '(php-doc-annotation-tag font-lock-doc-face)))
                (should (equal (get-text-property (1- (match-end i)) 'face)
-                              '(php-doc-annotation-tag-face font-lock-doc-face)))))
+                              '(php-doc-annotation-tag font-lock-doc-face)))))
 
     (search-forward "@property-read")
     (should (equal (get-text-property (match-beginning 0) 'face)
-                   '(php-doc-annotation-tag-face font-lock-doc-face)))
+                   '(php-doc-annotation-tag font-lock-doc-face)))
     (should (equal (get-text-property (1- (match-end 0)) 'face)
-                   '(php-doc-annotation-tag-face font-lock-doc-face)))))
+                   '(php-doc-annotation-tag font-lock-doc-face)))))
 
 (ert-deftest php-mode-test-issue-305 ()
   "Test highlighting variables which contains 'this' or 'that'."
   (with-php-mode-test ("issue-305.php")
     (search-forward "Start:")
     (search-forward "$this")
-    (should-not (eq 'php-constant-face (get-text-property (- (point) 1) 'face)))
+    (should-not (eq 'php-constant (get-text-property (- (point) 1) 'face)))
     (search-forward "$that")
-    (should-not (eq 'php-constant-face (get-text-property (- (point) 1) 'face)))))
+    (should-not (eq 'php-constant (get-text-property (- (point) 1) 'face)))))
 
 (ert-deftest php-mode-test-issue-307 ()
   "Activating php-mode should not mark the buffer as modified."

--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -719,7 +719,7 @@ style from Drupal."
       (dolist (variable variables)
         (search-forward variable)
         (goto-char (match-beginning 0))
-        (should (eq 'php-keyword-face
+        (should (eq 'php-keyword
                     (get-text-property (point) 'face)))))
     ;; when used as a cast, array should behave like other casts
     (search-forward "(array)")
@@ -754,26 +754,26 @@ style from Drupal."
     (search-forward "Start:")
     (while (not (= (line-number-at-pos) (count-lines (point-min) (point-max))))
       (forward-line 1)
-      (should (eq 'php-keyword-face
+      (should (eq 'php-keyword
                   (get-text-property (point) 'face))))))
 
 (ert-deftest php-mode-test-issue-178 ()
   "Highligth as keyword and following symbol"
   (with-php-mode-test ("issue-178.php")
     (search-forward "use Test as")
-    (should (eq 'php-keyword-face
+    (should (eq 'php-keyword
                 (get-text-property (- (point) 1) 'face)))
     (should (eq 'font-lock-type-face
                 (get-text-property (+ (point) 1) 'face)))
     (search-forward "$values as")
-    (should (eq 'php-keyword-face
+    (should (eq 'php-keyword
                 (get-text-property (- (point) 1) 'face)))
     (should (eq 'php-variable-name-face
                 (get-text-property (+ (point) 2) 'face)))
     (search-forward "test as")
-    (should (eq 'php-keyword-face
+    (should (eq 'php-keyword
                 (get-text-property (- (point) 1) 'face)))
-    (should (eq 'php-keyword-face
+    (should (eq 'php-keyword
                 (get-text-property (+ (point) 1) 'face)))))
 
 (ert-deftest php-mode-test-issue-186 ()
@@ -803,11 +803,11 @@ style from Drupal."
     (search-forward "$that")
     (should (eq 'php-constant-face (get-text-property (- (point) 1) 'face)))
     (search-forward "self")
-    (should (eq 'php-keyword-face (get-text-property (- (point) 1) 'face)))
+    (should (eq 'php-keyword (get-text-property (- (point) 1) 'face)))
     (search-forward "static")
-    (should (eq 'php-keyword-face (get-text-property (- (point) 1) 'face)))
+    (should (eq 'php-keyword (get-text-property (- (point) 1) 'face)))
     (search-forward "parent")
-    (should (eq 'php-keyword-face (get-text-property (- (point) 1) 'face)))))
+    (should (eq 'php-keyword (get-text-property (- (point) 1) 'face)))))
 
 (ert-deftest php-mode-test-issue-211 ()
   "Test indentation of string concatination"

--- a/php-mode.el
+++ b/php-mode.el
@@ -1675,7 +1675,7 @@ The output will appear in the buffer *PHP*."
 ;; Special care is taken to restore the original syntax, because we
 ;; want \ not to be word for functions like forward-word.
 (defadvice font-lock-fontify-keywords-region (around backslash-as-word activate)
-  "Fontify keywords with backslash as word character"
+  "Fontify keywords with backslash as word character."
   (let ((old-syntax (string (char-syntax ?\\))))
     (modify-syntax-entry ?\\ "w")
     ad-do-it

--- a/php-mode.el
+++ b/php-mode.el
@@ -1034,6 +1034,14 @@ PHP heredoc."
   "PHP Mode face used to highlight constants."
   :group 'php-faces)
 
+(defface php-$this '((t (:inherit php-constant)))
+  "PHP Mode face used to highlight $this variables."
+  :group 'php-faces)
+
+(defface php-$this-sigil '((t (:inherit php-constant)))
+  "PHP Mode face used to highlight sigils($) of $this variable."
+  :group 'php-faces)
+
 (defface php-php-tag '((t (:inherit font-lock-constant-face)))
   "PHP Mode face used to highlight PHP tags."
   :group 'php-faces)
@@ -1042,11 +1050,23 @@ PHP heredoc."
   "Face used to highlight annotation tags in doc-comment."
   :group 'php-faces)
 
+(defface php-doc-variable-sigil '((t (:inherit font-lock-variable-name-face)))
+  "PHP Mode face used to highlight variable sigils($)."
+  :group 'php-faces)
+
+(defface php-doc-$this '((t (:inherit php-type)))
+  "PHP Mode face used to highlight $this variable in doc-comment."
+  :group 'php-faces)
+
+(defface php-doc-$this-sigil '((t (:inherit php-type)))
+  "PHP Mode face used to highlight sigil of $this variable in doc-comment."
+  :group 'php-faces)
+
 (defface php-doc-class-name '((t (:inherit php-string)))
   "Face used to class names in doc-comment."
   :group 'php-faces)
 
-(define-obsolete-face-alias 'php-annotations-annotation-face 'php-doc-annotation-tag-face "1.19.0")
+(define-obsolete-face-alias 'php-annotations-annotation-face 'php-doc-annotation-tag "1.19.0")
 
 
 ;;;###autoload
@@ -1424,7 +1444,7 @@ a completion list."
 ;; Font Lock
 (defconst php-phpdoc-type-keywords
   (list "string" "integer" "int" "boolean" "bool" "float"
-        "double" "object" "mixed" "array" "resource" "$this"
+        "double" "object" "mixed" "array" "resource"
         "void" "null" "false" "true" "self" "static"
         "callable" "iterable" "number"))
 
@@ -1435,8 +1455,10 @@ a completion list."
   `(("{@[-[:alpha:]]+\\s-\\([^}]*\\)}" ; "{@foo ...}" markup.
      (0 'php-doc-annotation-tag prepend nil)
      (1 'php-string prepend nil))
-    (,(rx "$" (in "A-Za-z_") (* (in "0-9A-Za-z_")))
-     0 'php-variable-name prepend nil)
+    (,(rx (group "$") (group (in "A-Za-z_") (* (in "0-9A-Za-z_"))))
+     (1 'php-doc-variable-sigil prepend nil)
+     (2 'php-variable-name prepend nil))
+    ("\\(\\$\\)\\(this\\)\\>" (1 'php-doc-$this-sigil prepend nil) (2 'php-doc-$this prepend nil))
     (,(concat "\\s-@" (regexp-opt php-phpdoc-type-tags) "\\s-+"
               "\\(" (rx (+ (? "?") (? "\\") (+ (in "0-9A-Z_a-z")) (? "[]") (? "|"))) "\\)+")
      1 'php-string prepend nil)

--- a/php-mode.el
+++ b/php-mode.el
@@ -179,11 +179,11 @@ of constants when set."
   ;; remove old keywords
   (when (boundp 'php-extra-constants)
     (font-lock-remove-keywords
-     'php-mode `((,(php-mode-extra-constants-create-regexp php-extra-constants) 1 php-constant-face))))
+     'php-mode `((,(php-mode-extra-constants-create-regexp php-extra-constants) 1 'php-constant))))
   ;; add new keywords
   (when value
     (font-lock-add-keywords
-     'php-mode `((,(php-mode-extra-constants-create-regexp value) 1 php-constant-face))))
+     'php-mode `((,(php-mode-extra-constants-create-regexp value) 1 'php-constant))))
   (set sym value))
 
 (defcustom php-lineup-cascaded-calls nil
@@ -1017,43 +1017,43 @@ PHP heredoc."
 (defvar php-doc-annotation-tag-face 'php-doc-annotation-tag-face)
 (defvar php-doc-class-name-face 'php-doc-class-name-face)
 
-(defface php-string-face '((t (:inherit font-lock-string-face)))
+(defface php-string '((t (:inherit font-lock-string-face)))
   "PHP Mode face used to highlight string literals."
   :group 'php-faces)
 
-(defface php-keyword-face '((t (:inherit font-lock-keyword-face)))
+(defface php-keyword '((t (:inherit font-lock-keyword-face)))
   "PHP Mode face used to highlight keywords."
   :group 'php-faces)
 
-(defface php-builtin-face '((t (:inherit font-lock-builtin-face)))
+(defface php-builtin '((t (:inherit font-lock-builtin-face)))
   "PHP Mode face used to highlight builtins."
   :group 'php-faces)
 
-(defface php-function-name-face '((t (:inherit font-lock-function-name-face)))
+(defface php-function-name '((t (:inherit font-lock-function-name-face)))
   "PHP Mode face used to highlight function names."
   :group 'php-faces)
 
-(defface php-variable-name-face '((t (:inherit font-lock-variable-name-face)))
+(defface php-variable-name '((t (:inherit font-lock-variable-name-face)))
   "PHP Mode face used to highlight variable names."
   :group 'php-faces)
 
-(defface php-type-face '((t (:inherit font-lock-type-face)))
+(defface php-type '((t (:inherit font-lock-type-face)))
   "PHP Mode face used to highlight types."
   :group 'php-faces)
 
-(defface php-constant-face '((t (:inherit font-lock-constant-face)))
+(defface php-constant '((t (:inherit font-lock-constant-face)))
   "PHP Mode face used to highlight constants."
   :group 'php-faces)
 
-(defface php-php-tag-face '((t (:inherit font-lock-constant-face)))
+(defface php-php-tag '((t (:inherit font-lock-constant-face)))
   "PHP Mode face used to highlight PHP tags."
   :group 'php-faces)
 
-(defface php-doc-annotation-tag-face '((t . (:inherit font-lock-constant-face)))
+(defface php-doc-annotation-tag '((t . (:inherit font-lock-constant-face)))
   "Face used to highlight annotation tags in doc-comment."
   :group 'php-faces)
 
-(defface php-doc-class-name-face '((t (:inherit php-string-face)))
+(defface php-doc-class-name '((t (:inherit php-string)))
   "Face used to class names in doc-comment."
   :group 'php-faces)
 
@@ -1070,12 +1070,12 @@ PHP heredoc."
   (c-init-language-vars php-mode)
   (c-common-init 'php-mode)
 
-  (set (make-local-variable font-lock-string-face) php-string-face)
-  (set (make-local-variable font-lock-keyword-face) php-keyword-face)
-  (set (make-local-variable font-lock-builtin-face) php-builtin-face)
-  (set (make-local-variable font-lock-function-name-face) php-function-name-face)
-  (set (make-local-variable font-lock-variable-name-face) php-variable-name-face)
-  (set (make-local-variable font-lock-constant-face) php-constant-face)
+  (set (make-local-variable font-lock-string-face) 'php-string)
+  (set (make-local-variable font-lock-keyword-face) 'php-keyword)
+  (set (make-local-variable font-lock-builtin-face) 'php-builtin)
+  (set (make-local-variable font-lock-function-name-face) 'php-function-name)
+  (set (make-local-variable font-lock-variable-name-face) 'php-variable-name)
+  (set (make-local-variable font-lock-constant-face) 'php-constant)
 
   (modify-syntax-entry ?_    "_" php-mode-syntax-table)
   (modify-syntax-entry ?`    "\"" php-mode-syntax-table)
@@ -1444,13 +1444,13 @@ a completion list."
 
 (defconst php-phpdoc-font-lock-doc-comments
   `(("{@[-[:alpha:]]+\\s-\\([^}]*\\)}" ; "{@foo ...}" markup.
-     (0 php-doc-annotation-tag-face prepend nil)
-     (1 php-string-face prepend nil))
+     (0 'php-doc-annotation-tag prepend nil)
+     (1 'php-string prepend nil))
     (,(rx "$" (in "A-Za-z_") (* (in "0-9A-Za-z_")))
-     0 php-variable-name-face prepend nil)
+     0 'php-variable-name prepend nil)
     (,(concat "\\s-@" (regexp-opt php-phpdoc-type-tags) "\\s-+"
               "\\(" (rx (+ (? "?") (? "\\") (+ (in "0-9A-Z_a-z")) (? "[]") (? "|"))) "\\)+")
-     1 php-string-face prepend nil)
+     1 'php-string prepend nil)
     (,(concat "\\(?:|\\|\\?\\|\\s-\\)\\("
               (regexp-opt php-phpdoc-type-keywords 'words)
               "\\)")
@@ -1458,7 +1458,7 @@ a completion list."
     ("https?://[^\n\t ]+"
      0 'link prepend nil)
     ("^\\(?:/\\*\\)?\\(?:\\s \\|\\*\\)*\\(@[[:alpha:]][-[:alpha:]\\]*\\)" ; "@foo ..." markup.
-     1 php-doc-annotation-tag-face prepend nil)))
+     1 'php-doc-annotation-tag prepend nil)))
 
 (defvar php-phpdoc-font-lock-keywords
   `((,(lambda (limit)
@@ -1483,11 +1483,11 @@ a completion list."
      ("->\\(\\sw+\\)\\s-*(" 1 'default)
 
      ;; Highlight special variables
-     ("\\$\\(this\\|that\\)\\_>" 1 php-constant-face)
-     ("\\(\\$\\|->\\)\\([a-zA-Z0-9_]+\\)" 2 php-variable-name-face)
+     ("\\$\\(this\\|that\\)\\_>" 1 'php-constant)
+     ("\\(\\$\\|->\\)\\([a-zA-Z0-9_]+\\)" 2 'php-variable-name)
 
      ;; Highlight function/method names
-     ("\\<function\\s-+&?\\(\\(?:\\sw\\|\\s_\\)+\\)\\s-*(" 1 php-function-name-face)
+     ("\\<function\\s-+&?\\(\\(?:\\sw\\|\\s_\\)+\\)\\s-*(" 1 'php-function-name)
 
      ;; The dollar sign should not get a variable-name face, below
      ;; pattern resets the face to default in case cc-mode sets the
@@ -1500,7 +1500,7 @@ a completion list."
      ("(\\(array\\))" 1 font-lock-type-face)
 
      ;; Support the ::class constant in PHP5.6
-     ("\\sw+::\\(class\\)" 1 php-constant-face))
+     ("\\sw+::\\(class\\)" 1 'php-constant))
 
    ;; cc-mode patterns
    (c-lang-const c-matchers-3 php)
@@ -1514,15 +1514,15 @@ a completion list."
      ;; not in $obj->var()
      ("->\\(\\sw+\\)\\s-*(" 1 'default)
 
-     ("\\(\\$\\|->\\)\\([a-zA-Z0-9_]+\\)" 2 php-variable-name-face)
+     ("\\(\\$\\|->\\)\\([a-zA-Z0-9_]+\\)" 2 'php-variable-name)
 
      ;; Highlight all upper-cased symbols as constant
-     ("\\<\\([A-Z_][A-Z0-9_]+\\)\\>" 1 php-constant-face)
+     ("\\<\\([A-Z_][A-Z0-9_]+\\)\\>" 1 'php-constant)
 
      ;; Highlight all statically accessed class names as constant,
      ;; another valid option would be using type-face, but using
      ;; constant-face because this is how it works in c++-mode.
-     ("\\(\\sw+\\)::" 1 php-constant-face)
+     ("\\(\\sw+\\)::" 1 'php-constant)
 
      ;; Highlight class name after "use .. as"
      ("\\<as\\s-+\\(\\sw+\\)" 1 font-lock-type-face)
@@ -1550,7 +1550,7 @@ a completion list."
      ;;
      ;; Note that starting a file with <% breaks indentation, a
      ;; limitation we can/should live with.
-     (,(regexp-opt '("?>" "<?" "<%" "%>")) 0 php-php-tag-face)))
+     (,(regexp-opt '("?>" "<?" "<%" "%>")) 0 'php-php-tag)))
   "Detailed highlighting for PHP mode.")
 
 (defvar php-font-lock-keywords php-font-lock-keywords-3
@@ -1600,7 +1600,7 @@ The output will appear in the buffer *PHP*."
     (let ((quoted-stuff (nth 3 (syntax-ppss))))
       (when (and quoted-stuff (member quoted-stuff '(?\" ?`)))
         (put-text-property (match-beginning 0) (match-end 0)
-                           'face 'php-variable-name-face))))
+                           'face 'php-variable-name))))
   nil)
 
 (eval-after-load 'php-mode

--- a/php-mode.el
+++ b/php-mode.el
@@ -1006,17 +1006,6 @@ PHP heredoc."
   :group 'php
   :group 'faces)
 
-(defvar php-string-face 'php-string-face)
-(defvar php-keyword-face 'php-keyword-face)
-(defvar php-builtin-face 'php-builtin-face)
-(defvar php-function-name-face 'php-function-name-face)
-(defvar php-variable-name-face 'php-variable-name-face)
-(defvar php-type-face 'php-type-face)
-(defvar php-constant-face 'php-constant-face)
-(defvar php-php-tag-face 'php-php-tag-face)
-(defvar php-doc-annotation-tag-face 'php-doc-annotation-tag-face)
-(defvar php-doc-class-name-face 'php-doc-class-name-face)
-
 (defface php-string '((t (:inherit font-lock-string-face)))
   "PHP Mode face used to highlight string literals."
   :group 'php-faces)

--- a/php-mode.el
+++ b/php-mode.el
@@ -1022,8 +1022,36 @@ PHP heredoc."
   "PHP Mode face used to highlight function names."
   :group 'php-faces)
 
+(defface php-function-call '((t (:inherit default)))
+  "PHP Mode face used to highlight function names in calles."
+  :group 'php-faces)
+
+(defface php-method-call '((t (:inherit php-function-call)))
+  "PHP Mode face used to highlight method names in calles."
+  :group 'php-faces)
+
+(defface php-static-method-call '((t (:inherit php-method-call)))
+  "PHP Mode face used to highlight static method names in calles."
+  :group 'php-faces)
+
 (defface php-variable-name '((t (:inherit font-lock-variable-name-face)))
   "PHP Mode face used to highlight variable names."
+  :group 'php-faces)
+
+(defface php-property-name '((t (:inherit php-variable-name-face)))
+  "PHP Mode face used to highlight property names."
+  :group 'php-faces)
+
+(defface php-variable-sigil '((t (:inherit default)))
+  "PHP Mode face used to highlight variable sigils ($)."
+  :group 'php-faces)
+
+(defface php-object-op '((t (:inherit default)))
+  "PHP Mode face used to object operators (->)."
+  :group 'php-faces)
+
+(defface php-paamayim-nekudotayim '((t (:inherit default)))
+  "PHP Mode face used to highlight \"Paamayim Nekudotayim\" scope resolution operators (::)."
   :group 'php-faces)
 
 (defface php-type '((t (:inherit font-lock-type-face)))
@@ -1491,11 +1519,12 @@ a completion list."
    '(
      ;; Highlight variables, e.g. 'var' in '$var' and '$obj->var', but
      ;; not in $obj->var()
-     ("->\\(\\sw+\\)\\s-*(" 1 'default)
+     ("\\(->\\)\\(\\sw+\\)\\s-*(" (1 'php-object-op) (2 'php-method-call))
 
      ;; Highlight special variables
-     ("\\$\\(this\\|that\\)\\_>" 1 'php-constant)
-     ("\\(\\$\\|->\\)\\([a-zA-Z0-9_]+\\)" 2 'php-variable-name)
+     ("\\(\\$\\)\\(this\\|that\\)\\_>" (1 'php-$this-sigil) (2 'php-$this))
+     ("\\(\\$\\)\\([a-zA-Z0-9_]+\\)" (1 'php-variable-sigil) (2 'php-variable-name))
+     ("\\(->\\)\\([a-zA-Z0-9_]+\\)" (1 'php-object-op) (2 'php-property-name))
 
      ;; Highlight function/method names
      ("\\<function\\s-+&?\\(\\(?:\\sw\\|\\s_\\)+\\)\\s-*(" 1 'php-function-name)
@@ -1504,14 +1533,14 @@ a completion list."
      ;; pattern resets the face to default in case cc-mode sets the
      ;; variable-name face (cc-mode does this for variables prefixed
      ;; with type, like in arglist)
-     ("\\(\\$\\)\\(\\sw+\\)" 1 'default)
+     ("\\(\\$\\)\\(\\sw+\\)" 1 'php-variable-sigil)
 
      ;; Array is a keyword, except when used as cast, so that (int)
      ;; and (array) look the same
      ("(\\(array\\))" 1 font-lock-type-face)
 
      ;; Support the ::class constant in PHP5.6
-     ("\\sw+::\\(class\\)" 1 'php-constant))
+     ("\\sw+\\(::\\)\\(class\\)" (1 'php-paamayim-nekudotayim) (2 'php-constant)))
 
    ;; cc-mode patterns
    (c-lang-const c-matchers-3 php)
@@ -1523,9 +1552,9 @@ a completion list."
    `(
      ;; Highlight variables, e.g. 'var' in '$var' and '$obj->var', but
      ;; not in $obj->var()
-     ("->\\(\\sw+\\)\\s-*(" 1 'default)
+     ("->\\(\\sw+\\)\\s-*(" 1 'php-method-call)
 
-     ("\\(\\$\\|->\\)\\([a-zA-Z0-9_]+\\)" 2 'php-variable-name)
+     ("\\(\\$\\|->\\)\\([a-zA-Z0-9_]+\\)" 2 'php-property-name)
 
      ;; Highlight all upper-cased symbols as constant
      ("\\<\\([A-Z_][A-Z0-9_]+\\)\\>" 1 'php-constant)
@@ -1533,7 +1562,7 @@ a completion list."
      ;; Highlight all statically accessed class names as constant,
      ;; another valid option would be using type-face, but using
      ;; constant-face because this is how it works in c++-mode.
-     ("\\(\\sw+\\)::" 1 'php-constant)
+     ("\\(\\sw+\\)\\(::\\)" (1 'php-constant) (2 'php-paamayim-nekudotayim))
 
      ;; Highlight class name after "use .. as"
      ("\\<as\\s-+\\(\\sw+\\)" 1 font-lock-type-face)

--- a/tests/doc-comment-return-type.php
+++ b/tests/doc-comment-return-type.php
@@ -43,3 +43,8 @@
 /** @return int|\App\User    Multiple types by int and \App\User */
 /** @return DateTime|int    Multiple types by DateTime and int */
 /** @return \App\User|int    Multiple types by \App\User and int */
+
+// Test for $this
+
+/** @return $this this is special variable */
+/** @return $that that is NOT special variable */


### PR DESCRIPTION
refs #350 (Cc: @Fuco1)

This PR keeps appearance compatibility.


## Customized Example

Users will be able to easily match the color of `$` with variables as you like.

### Before (no customize)

<img width="238" alt="2017-04-07 2 12 50" src="https://cloud.githubusercontent.com/assets/822086/24766824/bff04074-1b37-11e7-8def-5b5a972beb48.png">

### After (customized)

<img width="234" alt="2017-04-07 1 55 59" src="https://cloud.githubusercontent.com/assets/822086/24766770/8af52498-1b37-11e7-946f-e4da61ce20a4.png">
