### PR TITLE
Improve highlighting of type hints and return types

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -733,20 +733,23 @@ style from Drupal."
 (ert-deftest php-mode-test-arrays()
   "Proper highlighting for array keyword."
   (with-php-mode-test ("arrays.php")
+    ;; Keyword situations
     (let ((variables '("array();"
-                       "array $test"
                        "array()")))
       (dolist (variable variables)
         (search-forward variable)
         (goto-char (match-beginning 0))
         (should (eq 'php-keyword
                     (get-text-property (point) 'face)))))
-    ;; when used as a cast, array should behave like other casts
-    (search-forward "(array)")
-    (goto-char (match-beginning 0))
-    (right-char)
-    (should (eq 'font-lock-type-face
-                (get-text-property (point) 'face)))))
+    ;; Type situations
+    (let ((variables '("(array)"
+                       "array $test"
+                       ": array")))
+      (dolist (variable variables)
+        (search-forward variable)
+        (search-backward "array")
+        (should (eq 'font-lock-type-face
+                    (get-text-property (point) 'face)))))))
 
 (ert-deftest php-mode-test-issue-174 ()
   "Test escaped quotes in string literals"
@@ -945,6 +948,33 @@ style from Drupal."
 (ert-deftest php-mode-test-issue-333 ()
   "Do not freeze Emacs by font-lock regexp pattern."
   (with-php-mode-test ("issue-333.php")))
+
+(ert-deftest php-mode-test-type-hints ()
+  "Test highlighting of type hints and return types."
+  (with-php-mode-test ("type-hints.php")
+    (search-forward "void")
+    (should (eq 'font-lock-type-face (get-text-property (- (point) 1) 'face)))
+    (dotimes (num 4)
+      (search-forward "string")
+      (should (eq 'font-lock-type-face (get-text-property (- (point) 1) 'face))))
+    (dotimes (num 4)
+      (search-forward "int")
+      (should (eq 'font-lock-type-face (get-text-property (- (point) 1) 'face))))
+    (dotimes (num 4)
+      (search-forward "float")
+      (should (eq 'font-lock-type-face (get-text-property (- (point) 1) 'face))))
+    (dotimes (num 4)
+      (search-forward "bool")
+      (should (eq 'font-lock-type-face (get-text-property (- (point) 1) 'face))))
+    (dotimes (num 4)
+      (search-forward "array")
+      (should (eq 'font-lock-type-face (get-text-property (- (point) 1) 'face))))
+    (dotimes (num 4)
+      (search-forward "stdClass")
+      (should (eq 'font-lock-type-face (get-text-property (- (point) 1) 'face))))
+    (dotimes (num 4)
+      (search-forward "\\path\\to\\my\\Object")
+      (should (eq 'font-lock-type-face (get-text-property (- (point) 1) 'face))))))
 
 ;;; php-mode-test.el ends here
 

--- a/php-mode.el
+++ b/php-mode.el
@@ -12,7 +12,7 @@
 (defconst php-mode-version-number "1.18.3"
   "PHP Mode version number.")
 
-(defconst php-mode-modified "2017-04-04"
+(defconst php-mode-modified "2017-04-07"
   "PHP Mode build date.")
 
 ;;; License
@@ -490,7 +490,7 @@ This variable can take one of the following symbol values:
 
 (c-lang-defconst c-primitive-type-kwds
   php '("int" "integer" "bool" "boolean" "float" "double" "real"
-        "string" "object"))
+        "string" "object" "void"))
 
 (c-lang-defconst c-class-decl-kwds
   "Keywords introducing declarations where the following block (if any)
@@ -552,7 +552,6 @@ PHP does not have an \"enum\"-like keyword."
     "array"
     "callable"
     "iterable"
-    "void"
     "as"
     "break"
     "catch all"
@@ -1535,9 +1534,13 @@ a completion list."
      ;; with type, like in arglist)
      ("\\(\\$\\)\\(\\sw+\\)" 1 'php-variable-sigil)
 
-     ;; Array is a keyword, except when used as cast, so that (int)
-     ;; and (array) look the same
+     ;; Array is a keyword, except in the following situations:
+     ;; - when used as cast, so that (int) and (array) look the same
+     ;; - when used as a type hint
+     ;; - when used as a return type
      ("(\\(array\\))" 1 font-lock-type-face)
+     ("\\b\\(array\\)\\s-+\\$" 1 font-lock-type-face)
+     (")\\s-*:\\s-*\\??\\(array\\)\\b" 1 font-lock-type-face)
 
      ;; Support the ::class constant in PHP5.6
      ("\\sw+\\(::\\)\\(class\\)" (1 'php-paamayim-nekudotayim) (2 'php-constant)))
@@ -1581,7 +1584,10 @@ a completion list."
       1 font-lock-type-face)
 
      ;; Highlight return types in functions and methods.
-     ("function.+:\\s-?\\(\\(?:\\sw\\|\\s_\\)+\\)" 1 font-lock-type-face)
+     ("function.+:\\s-?\\??\\(\\(?:\\sw\\|\\s_\\)+\\)" 1 font-lock-type-face)
+
+     ;; Highlight class names used as nullable type hints
+     ("\\?\\(\\(:?\\sw\\|\\s_\\)+\\)\\s-+\\$" 1 font-lock-type-face)
 
      ;; While c-opt-cpp-* highlights the <?php opening tags, it is not
      ;; possible to make it highlight short open tags and closing tags

--- a/tests/arrays.php
+++ b/tests/arrays.php
@@ -3,8 +3,14 @@
 // Array should be treated like a normal keyword
 $test = array();
 
-$test = function(array $test = array()) {
+$test = function($test = array()) {
 };
 
-// Unless it's a cast, then it should behave like (int)
+// Array should be treated as a type instead of a keyword in the following situations:
+// - cast, should look like `(int)`
+// - type hint, should look like `int $var`
+// - return type, should look like `: int`
 $test = (array)$test;
+
+$test = function(array $test): array {
+};

--- a/tests/language-constructs.php
+++ b/tests/language-constructs.php
@@ -75,7 +75,6 @@ try;
 unset();
 use ClassName;
 var;
-void;
 while;
 xor;
 yield;

--- a/tests/type-hints.php
+++ b/tests/type-hints.php
@@ -1,0 +1,64 @@
+<?php
+
+class SomeClass
+{
+    public function none($title): void
+    {
+    }
+
+    public function title(string $title): string
+    {
+    }
+
+    public function nullableTitle(?string $title): ?string
+    {
+    }
+
+    public function number(int $number): int
+    {
+    }
+
+    public function nullableNumber(?int $number): ?int
+    {
+    }
+
+    public function otherNumber(float $number): float
+    {
+    }
+
+    public function nullableOtherNumber(?float $number): ?float
+    {
+    }
+
+    public function flag(bool $flag): bool
+    {
+    }
+
+    public function nullableFlag(?bool $flag): ?bool
+    {
+    }
+
+    public function options(array $options): array
+    {
+    }
+
+    public function nullableOptions(?array $options): ?array
+    {
+    }
+
+    public function object(stdClass $object): stdClass
+    {
+    }
+
+    public function nullableObject(?stdClass $object): ?stdClass
+    {
+    }
+
+    public function nsObject(\path\to\my\Object $object): \path\to\my\Object
+    {
+    }
+
+    public function nullableNsObject(?\path\to\my\Object $object): ?\path\to\my\Object
+    {
+    }
+}


### PR DESCRIPTION
* Highlight `void` and `array` as types when used as type hints or return types (previously highlighted as keywords).

* Highlight nullable class names as types when used as type hints or return types (previously not highlighted).