### PR TITLE
Fix highlighting of static methods calls which start with `class`

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -663,7 +663,7 @@ style from Drupal."
                        "IS_CONSTANT99"
                        "extraconstant"
                        "ClassName"
-                       "class")))
+                       "class;")))
       (dolist (variable variables)
         (search-forward variable)
         (goto-char (match-beginning 0))
@@ -674,6 +674,7 @@ style from Drupal."
     (let ((variables '("no_constant"
                        "no_CONSTANT"
                        "extraconstant"
+                       "classIdentifier()"
                        "2FOO")))
       (dolist (variable variables)
         (search-forward variable)

--- a/php-mode.el
+++ b/php-mode.el
@@ -12,7 +12,7 @@
 (defconst php-mode-version-number "1.18.3"
   "PHP Mode version number.")
 
-(defconst php-mode-modified "2017-04-07"
+(defconst php-mode-modified "2017-04-19"
   "PHP Mode build date.")
 
 ;;; License
@@ -1543,7 +1543,7 @@ a completion list."
      (")\\s-*:\\s-*\\??\\(array\\)\\b" 1 font-lock-type-face)
 
      ;; Support the ::class constant in PHP5.6
-     ("\\sw+\\(::\\)\\(class\\)" (1 'php-paamayim-nekudotayim) (2 'php-constant)))
+     ("\\sw+\\(::\\)\\(class\\)\\b" (1 'php-paamayim-nekudotayim) (2 'php-constant)))
 
    ;; cc-mode patterns
    (c-lang-const c-matchers-3 php)

--- a/tests/constants.php
+++ b/tests/constants.php
@@ -21,6 +21,7 @@ ClassName::$test;
 
 // Class name resolution is a special case
 stdClass::class;
+SomeClass::classIdentifier();
 
 // Invalid constant name
 2FOO


### PR DESCRIPTION
Do not highlight the whole method name. The `class` part of the method was previously highlighted as a constant, e.g.

``` php
MyClass::className();
         ^^^^^
```