### PR TITLE
Fix highlighting of return types on different lines

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -975,7 +975,33 @@ style from Drupal."
       (should (eq 'font-lock-type-face (get-text-property (- (point) 1) 'face))))
     (dotimes (num 4)
       (search-forward "\\path\\to\\my\\Object")
-      (should (eq 'font-lock-type-face (get-text-property (- (point) 1) 'face))))))
+      (should (eq 'font-lock-type-face (get-text-property (- (point) 1) 'face))))
+    ;; Parameters on different lines
+    (let ((variables '("string"
+                       "int"
+                       "bool"
+                       "array"
+                       "stdClass"
+                       "\\path\\to\\my\\Object"
+                       "void")))
+      (dolist (variable variables)
+        (search-forward variable)
+        (should (eq 'font-lock-type-face (get-text-property (- (point) 1) 'face)))))
+    ;; Return types on different lines
+    (search-forward "void")
+    (should (eq 'font-lock-type-face (get-text-property (- (point) 1) 'face)))
+    (let ((variables '("string"
+                       "int"
+                       "float"
+                       "bool"
+                       "array"
+                       "stdClass"
+                       "\\path\\to\\my\\Object"
+                       )))
+      (dolist (variable variables)
+        (dotimes (num 2)
+          (search-forward variable)
+          (should (eq 'font-lock-type-face (get-text-property (- (point) 1) 'face))))))))
 
 ;;; php-mode-test.el ends here
 

--- a/php-mode.el
+++ b/php-mode.el
@@ -1584,7 +1584,8 @@ a completion list."
       1 font-lock-type-face)
 
      ;; Highlight return types in functions and methods.
-     ("function.+:\\s-?\\??\\(\\(?:\\sw\\|\\s_\\)+\\)" 1 font-lock-type-face)
+     ("function.+:\\s-*\\??\\(\\(?:\\sw\\|\\s_\\)+\\)" 1 font-lock-type-face)
+     (")\\s-*:\\s-*\\??\\(\\(?:\\sw\\|\\s_\\)+\\)\\s-*\{" 1 font-lock-type-face)
 
      ;; Highlight class names used as nullable type hints
      ("\\?\\(\\(:?\\sw\\|\\s_\\)+\\)\\s-+\\$" 1 font-lock-type-face)

--- a/tests/type-hints.php
+++ b/tests/type-hints.php
@@ -61,4 +61,75 @@ class SomeClass
     public function nullableNsObject(?\path\to\my\Object $object): ?\path\to\my\Object
     {
     }
+
+    public function someFunction(
+        $any,
+        string $name,
+        int $value,
+        bool $flag,
+        array $options,
+        stdClass $object,
+        \path\to\my\Object $nsObject
+    ): void {
+    }
+
+    public function getNone(
+    ): void {
+    }
+
+    public function getTitle(
+    ): string {
+    }
+
+    public function getNullableTitle(
+    ): ?string {
+    }
+
+    public function getNumber(
+    ): int {
+    }
+
+    public function getNullableNumber(
+    ): ?int {
+    }
+
+    public function getOtherNumber(
+    ): float {
+    }
+
+    public function getNullableOtherNumber(
+    ): ?float {
+    }
+
+    public function getFlag(
+    ): bool {
+    }
+
+    public function getNullableFlag(
+    ): ?bool {
+    }
+
+    public function getOptions(
+    ): array {
+    }
+
+    public function getNullableOptions(
+    ): ?array {
+    }
+
+    public function getObject(
+    ): stdClass {
+    }
+
+    public function getNullableObject(
+    ): ?stdClass {
+    }
+
+    public function getNsObject(
+    ): \path\to\my\Object {
+    }
+
+    public function getNullableNsObject(
+    ): ?\path\to\my\Object {
+    }
 }


### PR DESCRIPTION
Highlight class names used as return types even if the return type is specified on a different line than the `function` keyword (previously not highlighted).