### PR TITLE
Add php-mode-maybe for auto-mode-alist

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -153,6 +153,13 @@ Turning this on will open it whenever `php-mode' is loaded."
   "Should detect presence of html tags."
   :type 'boolean)
 
+(defcustom php-template-integrate-blade #'web-mode
+  "Automatically use another MAJOR-MODE when open Laravel Blade template file."
+  :type '(choice (function-item "web-mode is popular major mode" #'web-mode)
+                 (function :tag "Major mode for editing blade template")
+                 (const :tag "Do not use other major mode"))
+  :link '(url-link :tag "web-mode" "http://web-mode.org/"))
+
 (defsubst php-in-string-p ()
   (nth 3 (syntax-ppss)))
 
@@ -1097,6 +1104,17 @@ PHP heredoc."
 
 (define-obsolete-face-alias 'php-annotations-annotation-face 'php-doc-annotation-tag "1.19.0")
 
+;;;###autoload
+(defun php-mode-maybe ()
+  "Select PHP mode or other major mode."
+  (cond
+   ((and php-template-integrate-blade
+         buffer-file-name (string-match-p "\\.blade\\.php\\'" buffer-file-name))
+    (if (fboundp php-template-integrate-blade)
+        (prog1 t
+          (funcall php-template-integrate-blade))
+      (warn "php-mode is NOT support blade template")))
+   (:else (php-mode))))
 
 ;;;###autoload
 (define-derived-mode php-mode c-mode "PHP"

--- a/php-mode.el
+++ b/php-mode.el
@@ -1750,7 +1750,7 @@ The output will appear in the buffer *PHP*."
 
 ;;;###autoload
 (dolist (pattern '("\\.php[s345t]?\\'" "/\\.php_cs\\(\\.dist\\)?\\'" "\\.phtml\\'" "/Amkfile\\'" "\\.amk\\'"))
-  (add-to-list 'auto-mode-alist `(,pattern . php-mode) t))
+  (add-to-list 'auto-mode-alist `(,pattern . php-mode-maybe) t))
 
 (provide 'php-mode)
 


### PR DESCRIPTION
This change is somewhat strange, but the code is simple.
I kept this patch for four months, but I think that this PR may not be accepted.

The new function `feature/integrates-other-mode` abandons the work of php-mode under certain conditions and invoke another major mode.  This implementation is a bit odd but you can delegate files that are not good for php-mode to other major modes.

One of them is the Blade template.  This file generally has `.blade.php` extension, but it can not be edited in php-mode.  Fortunately web-mode supports Blade templates.  When web-mode is not installed in Emacs, simply announce warn and notify the user that php-mode is not suitable for editing the blade file.

----

## Back ground 1

Currently, many php-mode users **can not open `config.php`**.  When `php-mode` is auto loaded, its priority is lower in `auto-mode-alist` due to the `append` flag of `add-to-list`.  Because of that, `/config.php` [matches `conf-maybe-mode`](https://github.com/emacs-mirror/emacs/blob/65eee8392ff95f58f7b0bd036e1fe065523658c6/lisp/files.el#L2620).

Although I think that the `append` flag should be removed, I am worried that it may break the end users' setting compatibility.

## Back ground 2

[Blade](https://laravel.com/docs/5.4/blade) template file name has `.blade.php` extension.
Because the template language has its own control syntax, php-mode is useless.