### PR TITLE
Add auto-mode-alist for /config.php

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -1734,6 +1734,13 @@ The output will appear in the buffer *PHP*."
 (dolist (pattern '("\\.php[s345t]?\\'" "/\\.php_cs\\(\\.dist\\)?\\'" "\\.phtml\\'" "/Amkfile\\'" "\\.amk\\'"))
   (add-to-list 'auto-mode-alist `(,pattern . php-mode) t))
 
+;;;###autoload
+(progn
+  ;; matches `/config.php'
+  ;; refs https://github.com/ejmr/php-mode/pull/362#issuecomment-312404436
+  ;; To avoid conflict with default `conf-maybe-mode' in auto-mode-alist, add it explicitly.
+  (add-to-list 'auto-mode-alist '("[/.]c\\(?:on\\)?f\\(?:i?g\\)?\\(?:\\.[a-zA-Z0-9._-]+\\)?\\.php[s345t]?\\'" . php-mode)))
+
 (provide 'php-mode)
 
 ;;; php-mode.el ends here


### PR DESCRIPTION
refs #362

Currently, many php-mode users can not open config.php.
When php-mode is auto loaded, its priority is lower in auto-mode-alist
due to the append flag of add-to-list. Because of that, /config.php
matches conf-maybe-mode.

This patch is explicitly added to avoid conflict with the default
conf-maybe-mode in auto-mode-alist.