### PR TITLE
Add compatibility shim for interpreter-mode-alist and Emacs < 24.4

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -12,7 +12,7 @@
 (defconst php-mode-version-number "1.18.3"
   "PHP Mode version number.")
 
-(defconst php-mode-modified "2017-06-22"
+(defconst php-mode-modified "2017-09-07"
   "PHP Mode build date.")
 
 ;;; License
@@ -294,9 +294,12 @@ You can replace \"en\" with your ISO language code."
   :type 'string)
 
 ;;;###autoload
-(add-to-list 'interpreter-mode-alist
-             ;; Match php, php-3, php5, php7, php5.5, php-7.0.1, etc.
-             (cons "php\\(?:-?[3457]\\(?:\\.[0-9]+\\)*\\)?" 'php-mode))
+(if (version< emacs-version "24.4")
+    (dolist (i '("php" "php3" "php5" "php7" "php-5" "php-5.5" "php7.0.1"))
+      (add-to-list 'interpreter-mode-alist (cons i 'php-mode)))
+  (add-to-list 'interpreter-mode-alist
+               ;; Match php, php-3, php5, php7, php5.5, php-7.0.1, etc.
+               (cons "php\\(?:-?[3457]\\(?:\\.[0-9]+\\)*\\)?" 'php-mode)))
 
 (defcustom php-mode-hook nil
   "List of functions to be executed on entry to `php-mode'."


### PR DESCRIPTION
Emacs 24.4 changed the semantics of interpreter-mode-alist's members
from simple strings to regular expressions
(cf. http://git.savannah.gnu.org/cgit/emacs.git/commit/?id=1af4c2203ce7954c089133234ba80e6272ce9458).
Thus the current code does not set up interpreter-mode-alist correctly
for Emacs versions older than 24.4, causing the corresponding test to
fail.

This change adds a compatibility shim that either adds a list of
strings or a regular expression to interpreter-mode-alist depending on
the version of Emacs.  Theoretically, it does not cover all possible
interpreters matched by the regular expression, but all interpreters
listed in the test case work.