### PR TITLE
Fix Travis CI setup for Emacs snapshots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,20 +9,21 @@ env:
     - EMACS_VERSION=emacs-snapshot
 
 before_install:
-  # Use the ubuntu emacs teams regularly updated snapshot packages.
-  - if [ "$EMACS_VERSION" = 'emacs-snapshot' ]; then
-      sudo add-apt-repository -y ppa:ubuntu-elisp/ppa &&
-      sudo apt-get update -qq &&
-      sudo apt-get install -qq $EMACS_VERSION &&
-      sudo apt-get install -qq emacs-snapshot-el emacs-snapshot-nox;
+  - |
+    # Use the Ubuntu Emacs team's regularly updated snapshot packages.
+    if [ "$EMACS_VERSION" = emacs-snapshot ]; then
+        sudo add-apt-repository -y ppa:ubuntu-elisp/ppa &&
+        sudo apt-get update -qq &&
+        sudo apt-get install -qq emacs-snapshot-nox &&
+        sudo update-alternatives --set emacs $(which emacs-snapshot)
+    # Use Emacs Version Manager for all other versions.
+    else
+        sudo mkdir /usr/local/evm &&
+        sudo chown travis:travis /usr/local/evm &&
+        export PATH="/home/travis/.evm/bin:$PATH" &&
+        curl -fsSkL https://raw.github.com/rejeep/evm/master/go | bash &&
+        { evm install $EMACS_VERSION --use || true; }
     fi
-
-  # Use emacs version manager for all other versions.
-  - sudo mkdir /usr/local/evm
-  - sudo chown travis:travis /usr/local/evm
-  - export PATH="/home/travis/.evm/bin:$PATH"
-  - curl -fsSkL https://raw.github.com/rejeep/evm/master/go | bash
-  - evm install $EMACS_VERSION --use || true
 
 script:
   # Make sure the exact emacs version can be found in the build output.


### PR DESCRIPTION
The current Travis CI setup successfully installs the package
emacs-snapshot when tests against the development version of Emacs are
requested, but does not point the binary "emacs" at the snapshot
version, thus effectively running the test suite against the default
Emacs version (24.3.1).

This change invokes update-alternatives after the installation to make
the binary "emacs" refer to the snapshot version.  Additionally, it
does no longer (unsuccessfully) execute the Emacs Version Manager when
the snapshot setup is requested.