### PR TITLE
Remove Travis CI test for Emacs 25.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ env:
     - EMACS_VERSION=emacs-24.3-bin
     - EMACS_VERSION=emacs-24.4-bin
     - EMACS_VERSION=emacs-24.5-bin
-    - EMACS_VERSION=emacs-25.1-bin
     - EMACS_VERSION=emacs-snapshot
 
 before_install:


### PR DESCRIPTION
Emacs Version Manager (evm) currently does not seem to support
Emacs 25 in any way.  Installation attempts of "emacs-25.1-bin" and
"emacs-25.2-bin" fail with:

| No such package: emacs-25.1-bin

while "emacs-25.1-travis" and "emacs-25.2-travis" install, but are
dysfunctional:

| $ emacs -Q --batch --eval '(message (emacs-version))'
| Warning: arch-dependent data dir '/tmp/emacs-25.1-travis/libexec/emacs/25.1/x86_64-unknown-linux-gnu/': No such file or directory
| Warning: arch-independent data dir '/tmp/emacs-25.1-travis/share/emacs/25.1/etc/': No such file or directory
| Warning: Lisp directory '/tmp/emacs-25.1-travis/share/emacs/25.1/lisp': No such file or directory
| Error: charsets directory not found:
| /tmp/emacs-25.1-travis/share/emacs/25.1/etc/charsets
| Emacs will not function correctly without the character map files.
| Please check your installation!
| The command "emacs -Q --batch --eval '(message (emacs-version))'" exited with 1.

Until those issues are fixed in evm, any (doomed) attempt to test
against Emacs 25 only adds noise to php-mode's development.
Additionally, as Emacs 25 is the current official release and as such
in heavy use by both developers and users, testing (also)
automatically against that Emacs version is less of a concern; thus
this change removes the failing test for Emacs 25.1.