### PR TITLE
adapt new travis environment & more emacs versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,18 @@
 language: emacs-lisp
-sudo: required
 env:
   matrix:
-    - EMACS_VERSION=emacs-24.3-bin
-    - EMACS_VERSION=emacs-24.4-bin
-    - EMACS_VERSION=emacs-24.5-bin
-    - EMACS_VERSION=emacs-25.1-bin
-    - EMACS_VERSION=emacs-snapshot
+    - EMACS_VERSION=emacs-24.3-travis
+    - EMACS_VERSION=emacs-24.4-travis
+    - EMACS_VERSION=emacs-24.5-travis
+    - EMACS_VERSION=emacs-25.1-travis
+    - EMACS_VERSION=emacs-25.2-travis
+    - EMACS_VERSION=emacs-25.3-travis
+    - EMACS_VERSION=emacs-git-snapshot-travis
 
 before_install:
-  # Use the ubuntu emacs teams regularly updated snapshot packages.
-  - if [ "$EMACS_VERSION" = 'emacs-snapshot' ]; then
-      sudo add-apt-repository -y ppa:ubuntu-elisp/ppa &&
-      sudo apt-get update -qq &&
-      sudo apt-get install -qq $EMACS_VERSION &&
-      sudo apt-get install -qq emacs-snapshot-el emacs-snapshot-nox;
-    fi
-
-  # Use emacs version manager for all other versions.
-  - sudo mkdir /usr/local/evm
-  - sudo chown travis:travis /usr/local/evm
   - export PATH="/home/travis/.evm/bin:$PATH"
-  - curl -fsSkL https://raw.github.com/rejeep/evm/master/go | bash
+  - git clone https://github.com/rejeep/evm.git /home/travis/.evm
+  - evm config path /tmp
   - evm install $EMACS_VERSION --use || true
 
 script:


### PR DESCRIPTION
According to
https://github.com/rejeep/evm/blob/72f90d43fcac7861b620f2b6312e44e0604792e2/README.md
the *-bin packages are going to be deprecated because travis is moving
towards a container infrastructure.

Add two more recent emacs versions, 25.2 and 25.3, to the build
matrix.

Replace the ubuntu git-snapshot package with the one provided by evm,
this also ensures the correct version of emacs is running the tests.

Please note, there are failing tests because of known reasons:
emacs 24.3 php-mode-test-issue-357 in this version 'interpreter-mode-alist is not interpreted as regex
emacs git-snapshot: there was a change in the cpp preprocessor macro syntax that breaks single quote string test and indentation.