### PR TITLE
Add compatibility shim for interpreter-mode-alist and Emacs < 24.4

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -952,7 +952,9 @@ style from Drupal."
 
 (ert-deftest php-mode-test-issue-357 ()
   "Match version-specific interpreters."
-  (dolist (on '("php" "php3" "php5" "php7" "php-5" "php-5.5" "php7.0.1"))
+  (dolist (on (if (version< emacs-version "24.4")
+                  '("php" "php5" "php7")
+                '("php" "php3" "php5" "php7" "php-5" "php-5.5" "php7.0.1")))
     (with-temp-buffer
       (insert "#!" on)
       (set-auto-mode)

--- a/php-mode.el
+++ b/php-mode.el
@@ -294,9 +294,12 @@ You can replace \"en\" with your ISO language code."
   :type 'string)
 
 ;;;###autoload
-(add-to-list 'interpreter-mode-alist
-             ;; Match php, php-3, php5, php7, php5.5, php-7.0.1, etc.
-             (cons "php\\(?:-?[3457]\\(?:\\.[0-9]+\\)*\\)?" 'php-mode))
+(if (version< emacs-version "24.4")
+    (dolist (i '("php" "php3" "php5" "php7" "php-5" "php-5.5" "php7.0.1"))
+      (add-to-list 'interpreter-mode-alist (cons i 'php-mode)))
+  (add-to-list 'interpreter-mode-alist
+               ;; Match php, php-3, php5, php7, php5.5, php-7.0.1, etc.
+               (cons "php\\(?:-?[3457]\\(?:\\.[0-9]+\\)*\\)?" 'php-mode)))
 
 (defcustom php-mode-hook nil
   "List of functions to be executed on entry to `php-mode'."

--- a/php-mode.el
+++ b/php-mode.el
@@ -295,7 +295,7 @@ You can replace \"en\" with your ISO language code."
 
 ;;;###autoload
 (if (version< emacs-version "24.4")
-    (dolist (i '("php" "php3" "php5" "php7" "php-5" "php-5.5" "php7.0.1"))
+    (dolist (i '("php" "php5" "php7"))
       (add-to-list 'interpreter-mode-alist (cons i 'php-mode)))
   (add-to-list 'interpreter-mode-alist
                ;; Match php, php-3, php5, php7, php5.5, php-7.0.1, etc.


### PR DESCRIPTION
This PR is based on #372 by @scfc.

refs #378
