### PR TITLE
Add emacs-git-snapshot to travis allow_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ env:
     - EMACS_VERSION=emacs-25.2-travis
     - EMACS_VERSION=emacs-25.3-travis
     - EMACS_VERSION=emacs-git-snapshot-travis
+matrix:
+  allow_failures:
+  - env: EMACS_VERSION=emacs-git-snapshot-travis
 
 before_install:
   - export PATH="/home/travis/.evm/bin:$PATH"


### PR DESCRIPTION
refs #380

Suppress test failures in snapshots.
This issue does not affect the released versions, but we will deal with it as soon as possible.