### PR TITLE
Trivial refactor flymake

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -1590,7 +1590,7 @@ a completion list."
     (list php-executable (list "-f" local-file "-l"))))
 
 (add-to-list 'flymake-allowed-file-name-masks
-             '("\\.php[345s]?$"
+             '("\\.php[345s]?\\'"
                flymake-php-init
                flymake-simple-cleanup
                flymake-get-real-file-name))

--- a/php-mode.el
+++ b/php-mode.el
@@ -1586,8 +1586,13 @@ a completion list."
 
 This is an alternative function of `flymake-php-init'.
 Look at the `php-executable' variable instead of the constant \"php\" command."
-  (let* ((temp-file (flymake-init-create-temp-buffer-copy
-                     'flymake-create-temp-inplace))
+  (let* ((temp-file
+          (funcall
+           (eval-when-compile
+             (if (fboundp 'flymake-proc-init-create-temp-buffer-copy)
+                 'flymake-proc-init-create-temp-buffer-copy
+               'flymake-init-create-temp-buffer-copy))
+           'flymake-create-temp-inplace))
          (local-file (file-relative-name
                       temp-file
                       (file-name-directory buffer-file-name))))

--- a/php-mode.el
+++ b/php-mode.el
@@ -1581,7 +1581,11 @@ a completion list."
 ;;; Provide support for Flymake so that users can see warnings and
 ;;; errors in real-time as they write code.
 
-(defun flymake-php-init ()
+(defun php-flymake-php-init ()
+  "PHP specific init-cleanup routines.
+
+This is an alternative function of `flymake-php-init'.
+Look at the `php-executable' variable instead of the constant \"php\" command."
   (let* ((temp-file (flymake-init-create-temp-buffer-copy
                      'flymake-create-temp-inplace))
          (local-file (file-relative-name
@@ -1591,7 +1595,7 @@ a completion list."
 
 (add-to-list 'flymake-allowed-file-name-masks
              '("\\.php[345s]?\\'"
-               flymake-php-init
+               php-flymake-php-init
                flymake-simple-cleanup
                flymake-get-real-file-name))
 


### PR DESCRIPTION
## Changes

### 1. Function obsoleted

```
In php-flymake-php-init:
php-mode.el:1589:22:Warning: ‘flymake-init-create-temp-buffer-copy’ is an
    obsolete function (as of 26.1); use
    ‘flymake-proc-init-create-temp-buffer-copy’ instead.
```

### 2. Stop overwriting

Overriding standard functions is not generally a good method.

### 3. Fix regexp

Use `\'` instead of `$`.