### PR TITLE
fix #384 single quote string font locking in git-snapshot

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -429,6 +429,12 @@ This variable can take one of the following symbol values:
     map)
   "Keymap for `php-mode'")
 
+(c-lang-defconst c-get-state-before-change-functions
+  ;; const might be a symbol in older versions
+  php (let ((const (c-lang-const c-get-state-before-change-functions)))
+        (cl-set-difference (if (listp const) const (list const))
+                           '(c-parse-quotes-before-change))))
+
 (defun php-unescape-identifiers (beg end &optional old-len)
   "Change syntax of backslashes in identifiers between BEG and END, ignore OLD-LEN."
   (c-save-buffer-state (num-beg num-end)
@@ -446,8 +452,10 @@ This variable can take one of the following symbol values:
 (c-lang-defconst c-before-font-lock-functions
   ;; const might be a symbol in older versions
   php (let ((const (c-lang-const c-before-font-lock-functions)))
-        (append (if (listp const) const (list const))
-         '(php-unescape-identifiers))))
+        (append (cl-set-difference (if (listp const) const (list const))
+                                   '(c-restore-<>-properties
+                                     c-parse-quotes-after-change))
+                '(php-unescape-identifiers))))
 
 (c-lang-defconst c-mode-menu
   php (append '(["Complete function name" php-complete-function t]


### PR DESCRIPTION
In commit [59d07875df](https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=59d07875df9d44568d93a7517853e6a5ccaf1e5b) single quotes get a special handling in
`java-mode` and break `php-mode` string font locking.

By removing `c-parse-quotes-before-change` from `c-lang-const`
`c-get-state-before-change-functions`
and `c-parse-quotes-after-change` from `c-lang-const`
`c-before-font-lock-functions` font locking is working again in
git-snapshot.

And since php does not have generics also removing
`c-restore-<>-properties` from `c-lang-const` `c-before-font-lock-functions`
spares some processing time.