### PR TITLE
Add phpdoc keyword

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -356,6 +356,11 @@ style from Drupal."
     (search-forward-regexp "@link +\\(https://github.com/ejmr/php-mode\\)")
     (should (equal (get-text-property (match-beginning 1) 'face)
                    '(link font-lock-doc-face)))
+    (search-forward-regexp "@package +\\(Emacs\\\\PHPMode\\)")
+    (should (equal (get-text-property (match-beginning 0) 'face)
+                   '(php-doc-annotation-tag font-lock-doc-face)))
+    (should (equal (get-text-property (match-beginning 1) 'face)
+                   '(php-string font-lock-doc-face)))
 
 
     (search-forward-regexp "// \\(@annotation This is NOT annotation. 1\\)")
@@ -469,7 +474,15 @@ style from Drupal."
     (should (equal (get-text-property (match-beginning 2) 'face) ;; matches `i'
                    'font-lock-doc-face))
     (should (equal (get-text-property (match-end 2) 'face)       ;; matches ` '
-                   'font-lock-doc-face))))
+                   'font-lock-doc-face))
+
+    (search-forward-regexp "@throws \\(\\\\RuntimeException\\)$")
+    (should (equal (get-text-property (match-beginning 0) 'face) ;; matches `@'
+                   '(php-doc-annotation-tag font-lock-doc-face)))
+    (should (equal (get-text-property (match-beginning 1) 'face) ;; matches `\'
+                   '(php-string font-lock-doc-face)))
+    (should (equal (get-text-property (1+ (match-beginning 1)) 'face) ;; matches `R'
+                   '(php-string font-lock-doc-face)))))
 
 (ert-deftest php-mode-test-comment-return-type ()
   "Proper highlighting for type annotation in doc-block."

--- a/php-mode.el
+++ b/php-mode.el
@@ -1472,7 +1472,8 @@ a completion list."
         "callable" "iterable" "number"))
 
 (defconst php-phpdoc-type-tags
-  (list "param" "property" "property-read" "property-write" "return" "var"))
+  (list "package" "param" "property" "property-read" "property-write"
+        "return" "throws" "var"))
 
 (defconst php-phpdoc-font-lock-doc-comments
   `(("{@[-[:alpha:]]+\\s-\\([^}]*\\)}" ; "{@foo ...}" markup.

--- a/tests/comments.php
+++ b/tests/comments.php
@@ -8,6 +8,7 @@
  * @copyright 2011, 2012, 2013, 2014, 2015, 2016 Eric James Michael Ritz
  * @author    USAMI Kenta <tadsan@pixiv.com>
  * @link      https://github.com/ejmr/php-mode
+ * @package   Emacs\PHPMode
  */
 
 // one-line comment
@@ -59,5 +60,15 @@ final class SampleClass
 
         /** @var int internal linter variable */
         $offset = 0;
+    }
+
+    /**
+     * Summary
+     *
+     * @throws \RuntimeException
+     */
+    public function test()
+    {
+        throw new \RuntimeException;
     }
 }


### PR DESCRIPTION
These tags is defined in PHPDoc.

https://docs.phpdoc.org/references/phpdoc/tags/throws.html
https://docs.phpdoc.org/references/phpdoc/tags/package.html

However, `@category` and `@subpackage` tag are deprecated.
We do not explicitly support these tags.