### PR TITLE
fix some font-lock and indentation issues in emacs 25

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ In chronological order:
 72. tangxifan
 73. [Serghei Iakovlev](https://github.com/sergeyklay)
 74. [Christian Albrecht](https://github.com/calbrecht)
+75. [Sebastian Fieber](https://github.com/fallchildren)
 
 
 

--- a/php-mode.el
+++ b/php-mode.el
@@ -955,9 +955,17 @@ this ^ lineup"
 
 (defun php-syntax-propertize-function (start end)
   "Apply propertize rules from START to END."
+  (goto-char start)
+  (while (and (< (point) end)
+              (re-search-forward php-heredoc-start-re end t))
+    (php-heredoc-syntax))
+  (goto-char start)
+  (while (re-search-forward "['\"]" end t)
+    (when (php-in-comment-p)
+      (c-put-char-property (match-beginning 0)
+                           'syntax-table (string-to-syntax "_"))))
   (funcall
    (syntax-propertize-rules
-    (php-heredoc-start-re (0 (ignore (php-heredoc-syntax))))
     ("\\(\"\\)\\(\\\\.\\|[^\"\n\\]\\)*\\(\"\\)" (1 "\"") (3 "\""))
     ("\\(\'\\)\\(\\\\.\\|[^\'\n\\]\\)*\\(\'\\)" (1 "\"") (3 "\"")))
    start end))
@@ -1144,9 +1152,9 @@ After setting the stylevars run hooks according to STYLENAME
   (modify-syntax-entry ?_    "_" php-mode-syntax-table)
   (modify-syntax-entry ?`    "\"" php-mode-syntax-table)
   (modify-syntax-entry ?\"   "\"" php-mode-syntax-table)
-  (modify-syntax-entry ?'    "\"" php-mode-syntax-table)
   (modify-syntax-entry ?#    "< b" php-mode-syntax-table)
   (modify-syntax-entry ?\n   "> b" php-mode-syntax-table)
+  (modify-syntax-entry ?$    "'" php-mode-syntax-table)
 
   (setq-local syntax-propertize-function #'php-syntax-propertize-function)
   (add-to-list (make-local-variable 'syntax-propertize-extend-region-functions)

--- a/php-mode.el
+++ b/php-mode.el
@@ -472,6 +472,11 @@ SYMBOL
 (c-lang-defconst c-get-state-before-change-functions
   php nil)
 
+(c-lang-defconst c-before-font-lock-functions
+  php (if (fboundp #'c-depropertize-new-text)
+          '(c-depropertize-new-text)
+        nil))
+
 ;; Make php-mode recognize opening tags as preprocessor macro's.
 ;;
 ;; This is a workaround, the tags must be recognized as something
@@ -967,7 +972,7 @@ this ^ lineup"
   (funcall
    (syntax-propertize-rules
     ("\\(\"\\)\\(\\\\.\\|[^\"\n\\]\\)*\\(\"\\)" (1 "\"") (3 "\""))
-    ("\\(\'\\)\\(\\\\.\\|[^\'\n\\]\\)*\\(\'\\)" (1 "\"") (3 "\"")))
+    ("\\('\\)\\(\\\\.\\|[^'\n\\]\\)*\\('\\)" (1 "\"") (3 "\"")))
    start end))
 
 (defun php-heredoc-syntax ()

--- a/php-mode.el
+++ b/php-mode.el
@@ -942,9 +942,10 @@ this ^ lineup"
     (beginning-of-line)
     (if (looking-at-p "\\s-*;\\s-*$") 0 '+)))
 
-(defconst php-heredoc-start-re
-  "<<<\\(?:\\w+\\|'\\w+'\\)$"
-  "Regular expression for the start of a PHP heredoc.")
+(eval-and-compile
+  (defconst php-heredoc-start-re
+    "<<<\\(?:\\w+\\|'\\w+'\\)$"
+    "Regular expression for the start of a PHP heredoc."))
 
 (defun php-heredoc-end-re (heredoc-start)
   "Build a regular expression for the end of a heredoc started by the string HEREDOC-START."


### PR DESCRIPTION
- Removed advice "font-lock-fontify-keywords-region" (fixes GitHub Issue: #280)
- Changed syntax-propertize code to work with emacs 25 (fixes GitHub Issue: #371)
- Necessary code changes to replace the advice (font-locking for namespaces)