### PR TITLE
Fix highlighting of array keyword for parameters passed by reference

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -757,7 +757,8 @@ style from Drupal."
                     (get-text-property (point) 'face)))))
     ;; Type situations
     (let ((variables '("(array)"
-                       "array $test"
+                       "array $byValue"
+                       "array &$byReference"
                        ": array")))
       (dolist (variable variables)
         (search-forward variable)

--- a/php-mode.el
+++ b/php-mode.el
@@ -15,7 +15,7 @@
 (defconst php-mode-version-number "1.18.4"
   "PHP Mode version number.")
 
-(defconst php-mode-modified "2017-12-03"
+(defconst php-mode-modified "2018-01-25"
   "PHP Mode build date.")
 
 ;; This file is free software; you can redistribute it and/or
@@ -1553,7 +1553,7 @@ a completion list."
      ;; - when used as a type hint
      ;; - when used as a return type
      ("(\\(array\\))" 1 font-lock-type-face)
-     ("\\b\\(array\\)\\s-+\\$" 1 font-lock-type-face)
+     ("\\b\\(array\\)\\s-+&?\\$" 1 font-lock-type-face)
      (")\\s-*:\\s-*\\??\\(array\\)\\b" 1 font-lock-type-face)
 
      ;; Support the ::class constant in PHP5.6

--- a/tests/arrays.php
+++ b/tests/arrays.php
@@ -12,5 +12,5 @@ $test = function($test = array()) {
 // - return type, should look like `: int`
 $test = (array)$test;
 
-$test = function(array $test): array {
+$test = function(array $byValue, array &$byReference): array {
 };


### PR DESCRIPTION
`array` was highlighted as a keyword instead of a type hint when the parameter was passed by reference.