### PR TITLE
Add syntax highlight not supported by current php-mode

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -721,7 +721,12 @@ style from Drupal."
     (search-forward "SpaceName")
     (goto-char (match-beginning 0))
     (should (eq 'php-constant
-                (get-text-property (point) 'face)))))
+                (get-text-property (point) 'face)))
+    (search-forward-regexp "\\\\My_\\(Class\\)")
+    (should (eq 'php-constant
+                (get-text-property (match-beginning 0) 'face)))
+    (should (eq 'php-constant
+                (get-text-property (match-beginning 1) 'face)))))
 
 (ert-deftest php-mode-test-variables()
   "Proper highlighting for variables."

--- a/tests/identifiers.php
+++ b/tests/identifiers.php
@@ -13,3 +13,4 @@ $var\syntaxerror;
 // the constant face. Just like c++-mode "NS::Class::method()"
 ClassName::method();
 \SpaceName\ClassName::method();
+\My_Class::method();


### PR DESCRIPTION
I am aware that this problem is caused by #401, but it is also true that this testing method is unstable.