### PR TITLE
Fix delayed font-locking issue

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -485,9 +485,11 @@ SYMBOL
   php nil)
 
 (c-lang-defconst c-before-font-lock-functions
-  php (if (fboundp #'c-depropertize-new-text)
-          '(c-depropertize-new-text)
-        nil))
+  php (let (functions)
+        (when (fboundp #'c-change-expand-fl-region)
+          (cl-pushnew 'c-change-expand-fl-region functions))
+        (when (fboundp #'c-depropertize-new-text)
+          (cl-pushnew 'c-depropertize-new-text functions))))
 
 ;; Make php-mode recognize opening tags as preprocessor macro's.
 ;;


### PR DESCRIPTION
Due to a previous refactoring of the font-locking a bug was introduced
where font-locking was delayed. This happened because
c-before-font-lock-functions did not include the function
c-change-expand-fl-region. This commit adds it back to the cc-mode
variable, so font-locking will not be delayed.

Github Issue: #414 