### PR TITLE
Fix c-before-font-lock-functions

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -123,6 +123,16 @@ run with specific customizations set."
      (let ((case-fold-search nil))
        ,@body)))
 
+(ert-deftest php-mode-variables ()
+  "Check variables."
+  (with-php-mode-test ("script")
+    (if (or (fboundp #'c-change-expand-fl-region)
+            (fboundp #'c-depropertize-new-text))
+        (should (not (null (c-lang-const c-before-font-lock-functions)))))
+    (dolist (f (c-lang-const c-before-font-lock-functions))
+      (when (fboundp f)
+        (should (memq f '(c-change-expand-fl-region c-depropertize-new-text)))))))
+
 (ert-deftest php-mode-test-namespace-block ()
   "Proper indentation for classs and functions in namespace block."
   (with-php-mode-test ("namespace-block.php" :indent t :magic t)))

--- a/php-mode.el
+++ b/php-mode.el
@@ -485,11 +485,9 @@ SYMBOL
   php nil)
 
 (c-lang-defconst c-before-font-lock-functions
-  php (let (functions)
-        (when (fboundp #'c-change-expand-fl-region)
-          (cl-pushnew 'c-change-expand-fl-region functions))
-        (when (fboundp #'c-depropertize-new-text)
-          (cl-pushnew 'c-depropertize-new-text functions))))
+  php (cl-loop for f in '(c-change-expand-fl-region c-depropertize-new-text)
+               if (fboundp f)
+               collect f))
 
 ;; Make php-mode recognize opening tags as preprocessor macro's.
 ;;

--- a/php-mode.el
+++ b/php-mode.el
@@ -485,7 +485,7 @@ SYMBOL
   php nil)
 
 (c-lang-defconst c-before-font-lock-functions
-  php (cl-loop for f in '(c-change-expand-fl-region c-depropertize-new-text)
+  php (cl-loop for f in '(c-depropertize-new-text c-change-expand-fl-region)
                if (fboundp f)
                collect f))
 

--- a/tests/script
+++ b/tests/script
@@ -1,0 +1,4 @@
+#!/usr/bin/env php
+<?php
+
+var_dump(PHP_VERSION);


### PR DESCRIPTION
Before change, return of functions is missing.
I think the original correct code is as follows.

```el
(let (functions)
  (when (fboundp #'c-change-expand-fl-region)
    (cl-pushnew 'c-change-expand-fl-region functions))
  (when (fboundp #'c-depropertize-new-text)
    (cl-pushnew 'c-depropertize-new-text functions))
  functions)
```

Using cl-loop instead of when and cl-pushnew makes the code clearer.