### PR TITLE
Add php-mode-debug command

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -1151,6 +1151,25 @@ After setting the stylevars run hooks according to STYLENAME
 
 (put 'php-set-style 'interactive-form (interactive-form 'c-set-style))
 
+(defun php-mode-debug ()
+  "Display informations useful for debugging PHP Mode."
+  (interactive)
+  (message "--- PHP-MODE DEBUG BEGIN ---")
+  (message "versions: %s; %s" (emacs-version) (php-mode-version))
+  (message "major-mode: %s" major-mode)
+  (message "minor-modes: %s" (cl-remove-if
+                              (lambda (s) (string-match-p "global" (symbol-name s)))
+                              minor-mode-list))
+  (message "custom variables: %s"
+           (cl-loop for (v type) in (custom-group-members 'php nil)
+                    if (eq type 'custom-variable)
+                    collect (list v (symbol-value v))))
+  (message "c-indentation-style: %s" c-indentation-style)
+  (message "c-style-variables: %s" (c-get-style-variables c-indentation-style nil))
+  (message "--- PHP-MODE DEBUG END ---")
+  (switch-to-buffer "*Messages*")
+  (goto-char (point-max)))
+
 ;;;###autoload
 (define-derived-mode php-mode c-mode "PHP"
   "Major mode for editing PHP code.


### PR DESCRIPTION
This command is useful for PHPMode debugging and trouble reporting. In this change, we are aiming exclusively to collect variables. This command was inspired by `web-mode-debug`.