### PR TITLE
Use set and make-local-variable instead setq-local

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -1197,7 +1197,7 @@ After setting the stylevars run hooks according to STYLENAME
   (modify-syntax-entry ?\n   "> b" php-mode-syntax-table)
   (modify-syntax-entry ?$    "'" php-mode-syntax-table)
 
-  (setq-local syntax-propertize-function #'php-syntax-propertize-function)
+  (set (make-local-variable 'syntax-propertize-function) #'php-syntax-propertize-function)
   (add-to-list (make-local-variable 'syntax-propertize-extend-region-functions)
                #'php-syntax-propertize-extend-region)
 


### PR DESCRIPTION
`setq-local` was added in Emacs 24.3.
PHP Mode still keepscompatibility with Emacs 24.1, so we adopted redundant notation.