### PR TITLE
set c-before-font-lock-functions to default 't' value to not inherit java's value

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -65,8 +65,9 @@
 ;;; Code:
 
 (require 'cc-mode)
+(require 'cc-langs)
+
 (eval-when-compile
-  (require 'cc-langs)
   (require 'cc-fonts))
 
 ;; Boilerplate from other `cc-mode' derived modes. See
@@ -485,11 +486,7 @@ SYMBOL
   php nil)
 
 (c-lang-defconst c-before-font-lock-functions
-  php (let (functions)
-        (when (fboundp #'c-change-expand-fl-region)
-          (cl-pushnew 'c-change-expand-fl-region functions))
-        (when (fboundp #'c-depropertize-new-text)
-          (cl-pushnew 'c-depropertize-new-text functions))))
+  php (c-get-lang-constant 'c-before-font-lock-functions nil t))
 
 ;; Make php-mode recognize opening tags as preprocessor macro's.
 ;;


### PR DESCRIPTION
this will make the variable more portable through emacs versions

Reference to Pull Request #416 

Background:
java has to function in the variable we do not want:
- c-parse-quotes-after-change
- c-restore-<>-properties

as those are the only ones making java mode differ from the default
value we use that instead. The default value (which will be used if
no entry is in c-before-font-lock-functions for the used mode) has
changed from emacs 24 to master several times and may change in the
future. So this solution might spare us a few compability commits in
the future.