### PR TITLE
Add php-project-coding-style variable

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -37,6 +37,37 @@ GNU Emacs 24以降では、[package][]機能を使って[MELPA][]からPHPモー
 
 報告の際には `php-mode-version` コマンドを実行して、その出力をバグレポートに含めてください。問題を再現するための手がかりになります。
 
+Settings
+--------
+
+### 個人設定
+
+.emacsファイル(`~/.emacs.d/init.el`)にPHPモードでの設定を記述できます。
+
+```lisp
+(defun my-php-mode-init ()
+  (setq-local show-trailing-whitespace t)
+  (setq-local ac-disable-faces '(font-lock-comment-face font-lock-string-face))
+  (setq-local page-delimiter "\\_<\\(class\\|function\\|namespace\\)\\_>.+$")
+
+  ;; If you feel phumped and phpcs annoying, invalidate them.
+  (when (boundp 'flycheck-disabled-checkers)
+    (add-to-list 'flycheck-disabled-checkers 'php-phpmd)
+    (add-to-list 'flycheck-disabled-checkers 'php-phpcs)))
+
+(add-hook 'php-mode-hook #'my-php-mode-init)
+```
+
+### プロジェクトローカル設定
+
+プロジェクトのトップディレクトリに`.dir-locals.el`を記述すると、プロジェクト単位の設定を追加することができます。このファイルはユーザー自身のEmacsにインストールされたパッケージに依存するため、バージョン管理の対象に含めないことを推奨します。
+
+```lisp
+((nil
+  (php-project-root . git)
+  (php-project-coding-style . psr2)))
+```
+
 実験的および作業中の機能
 -------------------------------------
 

--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -275,14 +275,14 @@ style from Drupal."
    ;; the file written to has no significance, only the buffer
    (let ((tmp-filename (concat (make-temp-name temporary-file-directory) ".php")))
      (dolist (mode '(pear wordpress symfony2))
-       (php-mode-custom-coding-style-set 'php-mode-coding-style 'drupal)
-       (php-mode-custom-coding-style-set 'php-mode-coding-style mode)
+       (php-set-style "drupal")
+       (php-set-style (symbol-name mode))
        (should-not show-trailing-whitespace)
-       (php-mode-custom-coding-style-set 'php-mode-coding-style 'psr2)
-       (php-mode-custom-coding-style-set 'php-mode-coding-style mode)
+       (php-set-style "psr2")
+       (php-set-style (symbol-name mode))
        (should-not show-trailing-whitespace)
 
-       (php-mode-custom-coding-style-set 'php-mode-coding-style 'drupal)
+       (php-set-style "drupal")
        (write-file tmp-filename)
        (should (looking-at-p "$"))))))
 
@@ -871,7 +871,7 @@ style from Drupal."
 (ert-deftest php-mode-test-issue-200 ()
   "Test highlighting and elimination of extraneous whitespace in PSR-2 mode"
   (with-php-mode-test ("issue-200.php")
-    (php-mode-custom-coding-style-set 'php-mode-coding-style 'psr2)
+    (php-set-style "psr2")
     (should show-trailing-whitespace)
     (should (and (listp before-save-hook) (member 'delete-trailing-whitespace before-save-hook)))))
 

--- a/php-mode.el
+++ b/php-mode.el
@@ -383,6 +383,13 @@ This variable can take one of the following symbol values:
     (set-default sym value)
     (php-set-style (symbol-name value))))
 
+(defcustom php-mode-enable-project-coding-style t
+  "When set to true override php-mode-coding-style by php-project-coding-style.
+
+If you want to suppress styles from being overwritten by directory / file
+local variables, set NIL."
+  :type 'boolean)
+
 (defun php-mode-version ()
   "Display string describing the version of PHP Mode."
   (interactive)

--- a/php-mode.el
+++ b/php-mode.el
@@ -375,14 +375,8 @@ This variable can take one of the following symbol values:
                  (const :tag "WordPress" wordpress)
                  (const :tag "Symfony2" symfony2)
                  (const :tag "PSR-2" psr2))
-  :set 'php-mode-custom-coding-style-set
   :initialize 'custom-initialize-default)
 
-(defun php-mode-custom-coding-style-set (sym value)
-  (when (eq major-mode 'php-mode)
-    (set         sym value)
-    (set-default sym value)
-    (php-set-style (symbol-name value))))
 
 (defcustom php-mode-enable-project-coding-style t
   "When set to true override php-mode-coding-style by php-project-coding-style.

--- a/php-project.el
+++ b/php-project.el
@@ -33,6 +33,12 @@
 ;; Return root directory of current buffer file.  The root directory is
 ;; determined by several marker file or directory.
 ;;
+;; ## `.dir-locals.el' support
+;;
+;; - `php-project-coding-style'
+;;   - Symbol value of the coding style.  (ex.  `pear', `psr2')
+;;
+;;
 
 ;;; Code:
 (require 'cl-lib)
@@ -64,6 +70,16 @@ SYMBOL
   (make-variable-buffer-local 'php-project-root)
   (put 'php-project-root 'safe-local-variable
        #'(lambda (v) (assq v php-project-available-root-files))))
+
+;;;###autoload
+(progn
+  (defvar php-project-coding-style nil
+    "Symbol value of the coding style of the project that PHP major mode refers to.
+
+Typically it is `pear', `drupal', `wordpress', `symfony2' and `psr2'.")
+  (make-variable-buffer-local 'php-project-coding-style)
+  (put 'php-project-coding-style 'safe-local-variable #'symbolp))
+
 
 ;; Functions
 


### PR DESCRIPTION
This variable is introduced to locally override the customization variable php-mode-coding-style on a project basis.

It is set by the `.dir-locals.el` located in the directory, not the user's own `.emacs` file.