### PR TITLE
Add php-project-get-bootstrap-scripts functions

### DIFF
--- a/php-project.el
+++ b/php-project.el
@@ -37,7 +37,9 @@
 ;;
 ;; - `php-project-coding-style'
 ;;   - Symbol value of the coding style.  (ex.  `pear', `psr2')
-;;
+;; - `php-project-root'
+;;   - Symbol of marker file of project root.  (ex.  `git', `composer')
+;;   - Full path to project root directory.  (ex.  "/path/to/your-project")
 ;;
 
 ;;; Code:
@@ -86,12 +88,13 @@ Typically it is `pear', `drupal', `wordpress', `symfony2' and `psr2'.")
 ;;;###autoload
 (defun php-project-get-root-dir ()
   "Return path to current PHP project."
-  (let ((detect-method (if (stringp php-project-root)
-                           (list php-project-root)
-                         (if (eq php-project-root 'auto)
-                             (cl-loop for m in php-project-available-root-files
-                                      append (cdr m))
-                           (cdr-safe (assq php-project-root php-project-available-root-files))))))
+  (let ((detect-method
+         (cond
+          ((stringp php-project-root) (list php-project-root))
+          ((eq php-project-root 'auto)
+           (cl-loop for m in php-project-available-root-files
+                    append (cdr m)))
+          (t (cdr-safe (assq php-project-root php-project-available-root-files))))))
     (cl-loop for m in detect-method
              thereis (locate-dominating-file default-directory m))))
 

--- a/php-project.el
+++ b/php-project.el
@@ -52,6 +52,9 @@
 ;;; Code:
 (require 'cl-lib)
 
+;; Constants
+(defconst php-project-composer-autoloader "vendor/autoload.php")
+
 ;; Variables
 (defvar php-project-available-root-files
   '((projectile ".projectile")
@@ -106,6 +109,9 @@ Typically it is `pear', `drupal', `wordpress', `symfony2' and `psr2'.")
   "Return T when `VAL' is valid list of safe bootstrap php script."
   (cond
    ((stringp val) (and (file-exists-p val) val))
+   ((eq 'composer val)
+    (let ((path (expand-file-name php-project-composer-autoloader (php-project-get-root-dir))))
+      (and (file-exists-p path) path)))
    ((and (consp val) (eq 'root (car val)) (stringp (cdr val)))
     (let ((path (expand-file-name (cdr val) (php-project-get-root-dir))))
       (and (file-exists-p path) path)))


### PR DESCRIPTION
These files are used for PHP initialization processing for dynamic analysis of definitions.