### PR TITLE
Remove Subword mode toggle

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -423,10 +423,7 @@ local variables, set NIL."
     ;;     https://www.gnu.org/software/emacs/manual/html_node/ccmode/Subword-Movement.html
     ;;
     ;; for more information about Submode Word.
-    (if (boundp 'subword-mode)
-        (if subword-mode
-            (subword-mode nil)
-          (subword-mode t)))
+    (define-key map (kbd "C-c C-w") 'subword-mode)
 
     ;; We inherit c-beginning-of-defun and c-end-of-defun from CC Mode
     ;; but we have two replacement functions specifically for PHP.  We

--- a/php-mode.el
+++ b/php-mode.el
@@ -422,7 +422,7 @@ local variables, set NIL."
     ;;
     ;;     https://www.gnu.org/software/emacs/manual/html_node/ccmode/Subword-Movement.html
     ;;
-    ;; for more information about Submode Word.
+    ;; for more information about Subword mode.
     (define-key map (kbd "C-c C-w") 'subword-mode)
 
     ;; We inherit c-beginning-of-defun and c-end-of-defun from CC Mode


### PR DESCRIPTION
refs #89 

This change was introduced in 5a1f99d89ee675aacc4e4868f772e8f78ffaa159, but there is no point in toggling the mode when defining a keymap.
