### PR TITLE
Do not use php-mode-enable-backup-style-variables in initialize

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -1264,7 +1264,8 @@ After setting the stylevars run hooks according to STYLENAME
         (setq php-mode--delayed-set-style t)
         (when (fboundp 'advice-add)
           (advice-add #'c-set-style :after #'php-mode--disable-delay-set-style '(local))))
-    (php-set-style (symbol-name php-mode-coding-style)))
+    (let ((php-mode-enable-backup-style-variables nil))
+      (php-set-style (symbol-name php-mode-coding-style))))
 
   (when (or php-mode-force-pear
             (and (stringp buffer-file-name)


### PR DESCRIPTION
During initialization the variable backup had to be invalidated. Because of that, the default indentation style was adversely affected, so it will be fixed.