### PR TITLE
Add c-lang-defconst c-anchored-cpp-prefix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ env:
     - EMACS_VERSION=emacs-25.2-travis
     - EMACS_VERSION=emacs-25.3-travis
     - EMACS_VERSION=emacs-git-snapshot-travis
-matrix:
-  allow_failures:
-  - env: EMACS_VERSION=emacs-git-snapshot-travis
+# matrix:
+#   allow_failures:
+#   - env: EMACS_VERSION=emacs-git-snapshot-travis
 
 before_install:
   - export PATH="/home/travis/.evm/bin:$PATH"

--- a/php-mode.el
+++ b/php-mode.el
@@ -486,6 +486,9 @@ In that case set to `NIL'."
 (c-lang-defconst c-opt-cpp-prefix
   php "\\s-*<\\?")
 
+(c-lang-defconst c-anchored-cpp-prefix
+  php "\\s-*\\(<\\?(=\\|\\sw+)\\)")
+
 (c-lang-defconst c-identifier-ops
   php '(
         (left-assoc "\\" "::" "->")


### PR DESCRIPTION
This is the cause of the error that occurred in Emacs snapshots (later 25) and 26 development versions. We must confess that we did not know how to debug Emacs Lisp and CC Mode.

PHP Mode inherits the properties of java-mode, but Java has no preprocessor, and PHP defined `c-opt-cpp-prefix` for PHP tags.  Therefore, by properly defining `c-anchored-cpp-prefix`, errors are prevented from occurring.

This error was c-macro-is-genuine-p called from c-beginning-of-macro, but this problem is obscured by the huge `condition-case` of `c-syntactic-re-search-forward`.