### PR TITLE
README: Update the list of maintainers to be accurate

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -13,14 +13,14 @@ PHP 5.4以降を開発しやすくするための機能をアップデートす�
 1. Turadg Aleahmad (Original Author)
 2. Aaron S. Hawley
 3. Lennart Borgman
+4. Eric James Michael Ritz
+5. Syohei Yoshida
 
 リストアップされたすべての貢献者たちも同様にPHPモードを改善しました。
 
 現在のメンテナ：
 
-1. Syohei Yoshida
-2. Eric James Michael Ritz
-3. USAMI Kenta (@zonuexe)
+1. USAMI Kenta (@zonuexe)
 
 [PHPモードのGitHubプロジェクト](https://github.com/ejmr/php-mode)にissueを作成してバグ報告や機能リクエストを送ってください。
 

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ This project updates PHP Mode for GNU Emacs with features to make it more friend
 1. Turadg Aleahmad (Original Author)
 2. Aaron S. Hawley
 3. Lennart Borgman
+4. Eric James Michael Ritz
+5. Syohei Yoshida
 
 All contributors listed below improved PHP Mode as well.
 
-The current maintainers are:
+The current maintainer is:
 
-1. Syohei Yoshida
-2. Eric James Michael Ritz
-3. USAMI Kenta (@zonuexe)
+1. USAMI Kenta (@zonuexe)
 
 Please submit any bug reports or feature requests by creating issues on [the GitHub page for PHP Mode](https://github.com/ejmr/php-mode).
 


### PR DESCRIPTION
I am no longer an active maintainer of PHP Mode, nor is Syohei Yoshida.
The GitHub issues referenced below provide details about how neither of us
are actively involved in the maintenance of PHP Mode.  Those references
also describe how Usami Kenta is the lead maintianer, which this patch
reflects.

GitHub-Issue: #365
GitHub-Issue: #387
Signed-off-by: Eric James Michael Ritz