### PR TITLE
Fix require and supress error messages of byte compile

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -84,7 +84,7 @@
 (require 'speedbar)
 (require 'imenu)
 (require 'nadvice nil t)
-(require 'php-project nil t)
+(require 'package)
 
 (require 'cl-lib)
 (require 'mode-local)
@@ -1182,6 +1182,8 @@ After setting the stylevars run hooks according to STYLENAME
   (declare (indent 1))
   (php-mode-debug--buffer 'insert (apply #'format format-string args) "\n"))
 
+(declare-function custom-group-members "cus-edit" (symbol groups-only))
+
 (defun php-mode-debug ()
   "Display informations useful for debugging PHP Mode."
   (interactive)
@@ -1308,6 +1310,9 @@ After setting the stylevars run hooks according to STYLENAME
     (with-silent-modifications
       (save-excursion
         (php-syntax-propertize-function (point-min) (point-max))))))
+
+
+(declare-function semantic-create-imenu-index "semantic/imenu" (&optional stream))
 
 (defvar-mode-local php-mode imenu-create-index-function
   (if php-do-not-use-semantic-imenu


### PR DESCRIPTION
`declare-function` is a directive that notifies the byte compiler of function definition information.
This suppresses unnecessary error messages during byte compilation.

## Before

```
% make
emacs -Q -batch -L . --eval \
	"(progn \
	   (require 'package) \
	   (package-generate-autoloads \"php-mode\" default-directory))"
Generating autoloads for php-cc-mode.el...
Generating autoloads for php-cc-mode.el...done
Generating autoloads for php-core.el...
Generating autoloads for php-core.el...done
Generating autoloads for php-mode-test.el...
Generating autoloads for php-mode-test.el...done
Generating autoloads for php-mode.el...
Generating autoloads for php-mode.el...done
Generating autoloads for php-project.el...
Generating autoloads for php-project.el...done
Generating autoloads for tiny-init.el...
Generating autoloads for tiny-init.el...done
Wrote /Users/megurine/repo/emacs/php-mode/php-mode-autoloads.el
Wrote /Users/megurine/repo/emacs/php-mode/php-mode-autoloads.el
emacs -Q -batch -L . -f batch-byte-compile php-project.el
emacs -Q -batch -L . -f batch-byte-compile php-mode.el

In end of data:
php-mode.el:1854:1:Warning: the following functions are not known to be
    defined: package-desc-status, package-version-join, package-desc-version,
    custom-group-members, semantic-create-imenu-index
emacs -Q -batch -L . -f batch-byte-compile php-mode-test.el
```

## After

```
% make
emacs -Q -batch -L . --eval \
	"(progn \
	   (require 'package) \
	   (package-generate-autoloads \"php-mode\" default-directory))"
Generating autoloads for php-cc-mode.el...
Generating autoloads for php-cc-mode.el...done
Generating autoloads for php-core.el...
Generating autoloads for php-core.el...done
Generating autoloads for php-mode-test.el...
Generating autoloads for php-mode-test.el...done
Generating autoloads for php-mode.el...
Generating autoloads for php-mode.el...done
Generating autoloads for php-project.el...
Generating autoloads for php-project.el...done
Generating autoloads for tiny-init.el...
Generating autoloads for tiny-init.el...done
Wrote /Users/megurine/repo/emacs/php-mode/php-mode-autoloads.el
Wrote /Users/megurine/repo/emacs/php-mode/php-mode-autoloads.el
emacs -Q -batch -L . -f batch-byte-compile php-project.el
emacs -Q -batch -L . -f batch-byte-compile php-mode.el
emacs -Q -batch -L . -f batch-byte-compile php-mode-test.el
```