### PR TITLE
Make php-project-root accept a string

### DIFF
--- a/php-project.el
+++ b/php-project.el
@@ -95,10 +95,15 @@
       Try to search file in order of `php-project-available-root-files'.
 
 SYMBOL
-      Key of `php-project-available-root-files'.")
+      Key of `php-project-available-root-files'.
+
+STRING
+      A file/directory name of top level marker.
+      If the string is an actual directory path, it is set as the absolute path
+      of the root directory, not the marker.")
   (make-variable-buffer-local 'php-project-root)
   (put 'php-project-root 'safe-local-variable
-       #'(lambda (v) (assq v php-project-available-root-files))))
+       #'(lambda (v) (or (stringp v) (assq v php-project-available-root-files)))))
 
 ;;;###autoload
 (progn
@@ -177,15 +182,17 @@ Typically it is `pear', `drupal', `wordpress', `symfony2' and `psr2'.")
 ;;;###autoload
 (defun php-project-get-root-dir ()
   "Return path to current PHP project."
-  (let ((detect-method
-         (cond
-          ((stringp php-project-root) (list php-project-root))
-          ((eq php-project-root 'auto)
-           (cl-loop for m in php-project-available-root-files
-                    append (cdr m)))
-          (t (cdr-safe (assq php-project-root php-project-available-root-files))))))
-    (cl-loop for m in detect-method
-             thereis (locate-dominating-file default-directory m))))
+  (if (and (stringp php-project-root) (file-directory-p php-project-root))
+      php-project-root
+    (let ((detect-method
+           (cond
+            ((stringp php-project-root) (list php-project-root))
+            ((eq php-project-root 'auto)
+             (cl-loop for m in php-project-available-root-files
+                      append (cdr m)))
+            (t (cdr-safe (assq php-project-root php-project-available-root-files))))))
+      (cl-loop for m in detect-method
+               thereis (locate-dominating-file default-directory m)))))
 
 (provide 'php-project)
 ;;; php-project.el ends here


### PR DESCRIPTION
This change helps users to identify project-specific directories.
There is usually no risk of conflict between the file name of the marker and the directory name.
In the future, it is possible to control the behavior when the directory name was not the parent directory of the buffer file.